### PR TITLE
feat: sign with manifest builder

### DIFF
--- a/pkg/api/stream_key.go
+++ b/pkg/api/stream_key.go
@@ -88,9 +88,9 @@ func (a *StreamplaceAPI) MakeMediaSigner(ctx context.Context, keyStr string) (me
 
 	var mediaSigner media.MediaSigner
 	if a.CLI.ExternalSigning {
-		mediaSigner, err = media.MakeMediaSignerExt(ctx, a.CLI, did, addrBytes)
+		mediaSigner, err = media.MakeMediaSignerExt(ctx, a.CLI, did, addrBytes, a.Model)
 	} else {
-		mediaSigner, err = media.MakeMediaSigner(ctx, a.CLI, did, signer)
+		mediaSigner, err = media.MakeMediaSigner(ctx, a.CLI, did, signer, a.Model)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("invalid authorization key (not valid secp256k1): %w", err)

--- a/pkg/cmd/sign.go
+++ b/pkg/cmd/sign.go
@@ -4,14 +4,17 @@ import (
 	"bytes"
 	"context"
 	"crypto/ecdsa"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
 	"os"
 
+	"git.stream.place/streamplace/c2pa-go/pkg/c2pa"
 	"github.com/decred/dcrd/dcrec/secp256k1"
 	"github.com/mr-tron/base58"
 	"stream.place/streamplace/pkg/crypto/aqpub"
+	"stream.place/streamplace/pkg/log"
 	"stream.place/streamplace/pkg/media"
 )
 
@@ -22,9 +25,15 @@ func Sign(ctx context.Context) error {
 	streamerName := fs.String("streamer", "", "streamer name")
 	taURL := fs.String("ta-url", "http://timestamp.digicert.com", "timestamp authority server for signing")
 	startTime := fs.Int64("start-time", 0, "start time of the stream")
+	manifestJSON := fs.String("manifest", "", "JSON manifest to use for signing")
 	if err := fs.Parse(os.Args[2:]); err != nil {
 		return err
 	}
+
+	log.Debug(ctx, "Sign command: starting", 
+		"streamer", *streamerName,
+		"startTime", *startTime,
+		"hasManifest", *manifestJSON != "")
 
 	keyBs, err := base58.Decode(*key)
 	if err != nil {
@@ -51,12 +60,30 @@ func Sign(ctx context.Context) error {
 		return err
 	}
 
+	var manifest *c2pa.ManifestDefinition
+	if *manifestJSON != "" {
+		log.Debug(ctx, "Sign command: parsing provided manifest JSON", "jsonLength", len(*manifestJSON))
+		
+		// Parse the provided manifest directly as C2PA manifest
+		if err := json.Unmarshal([]byte(*manifestJSON), &manifest); err != nil {
+			log.Error(ctx, "Sign command: failed to parse manifest JSON", "error", err)
+			return fmt.Errorf("failed to parse manifest JSON: %w", err)
+		}
+		
+		log.Debug(ctx, "Sign command: successfully parsed manifest", 
+			"title", manifest.Title,
+			"assertionsCount", len(manifest.Assertions))
+	} else {
+		log.Debug(ctx, "Sign command: no manifest provided, will use default")
+	}
+
 	ms := &media.MediaSignerLocal{
 		Signer:       signer,
 		Cert:         certBs,
 		StreamerName: *streamerName,
 		TAURL:        *taURL,
 		AQPub:        pub,
+		Manifest:     manifest,  // Pass manifest to local signer
 	}
 
 	inputBs, err := io.ReadAll(os.Stdin)

--- a/pkg/cmd/streamplace.go
+++ b/pkg/cmd/streamplace.go
@@ -310,7 +310,7 @@ func start(build *config.BuildFlags, platformJobs []jobFunc) error {
 		return err
 	}
 
-	ms, err := media.MakeMediaSigner(ctx, &cli, cli.StreamerName, signer)
+	ms, err := media.MakeMediaSigner(ctx, &cli, cli.StreamerName, signer, mod)
 	if err != nil {
 		return err
 	}
@@ -412,7 +412,7 @@ func start(build *config.BuildFlags, platformJobs []jobFunc) error {
 			return err
 		}
 		did := atkey.DIDKey()
-		testMediaSigner, err := media.MakeMediaSigner(ctx, &cli, did, testSigner)
+		testMediaSigner, err := media.MakeMediaSigner(ctx, &cli, did, testSigner, mod)
 		if err != nil {
 			return err
 		}
@@ -443,7 +443,7 @@ func start(build *config.BuildFlags, platformJobs []jobFunc) error {
 			return err
 		}
 		did2 := atkey2.DIDKey()
-		intermittentMediaSigner, err := media.MakeMediaSigner(ctx, &cli, did2, intermittentSigner)
+		intermittentMediaSigner, err := media.MakeMediaSigner(ctx, &cli, did2, intermittentSigner, mod)
 		if err != nil {
 			return err
 		}

--- a/pkg/media/manifest_builder.go
+++ b/pkg/media/manifest_builder.go
@@ -112,6 +112,26 @@ func (mb *ManifestBuilder) enhanceManifestWithMetadata(mani obj, metadata *strea
 	}
 
 	if len(metadata.ContentWarnings) > 0 {
+		// Map internal warning codes to C2PA warning codes
+		var warningCodeMap = map[string]string{
+			"place.stream.default.metadata#death":           "cwarn:death",
+			"place.stream.default.metadata#drugUse":         "cwarn:drugUse",
+			"place.stream.default.metadata#fantasyViolence": "cwarn:fantasyViolence",
+			"place.stream.default.metadata#flashingLights":  "cwarn:flashingLights",
+			"place.stream.default.metadata#language":        "cwarn:language",
+			"place.stream.default.metadata#nudity":          "cwarn:nudity",
+			"place.stream.default.metadata#PII":             "cwarn:PII",
+			"place.stream.default.metadata#sexuality":       "cwarn:sexuality",
+			"place.stream.default.metadata#suffering":       "cwarn:suffering",
+			"place.stream.default.metadata#violence":        "cwarn:violence",
+		}
+		
+		for i, warning := range metadata.ContentWarnings {
+			if mappedCode, exists := warningCodeMap[warning]; exists {
+				metadata.ContentWarnings[i] = mappedCode
+			}
+			// Unknown warnings remain unchanged
+		}
 		mani["assertions"].([]obj)[1]["data"].(obj)["Iptc4xmpExt:ContentWarning"] = metadata.ContentWarnings
 	}
 

--- a/pkg/media/manifest_builder.go
+++ b/pkg/media/manifest_builder.go
@@ -1,0 +1,123 @@
+package media
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"git.stream.place/streamplace/c2pa-go/pkg/c2pa"
+	"stream.place/streamplace/pkg/aqtime"
+	"stream.place/streamplace/pkg/log"
+	"stream.place/streamplace/pkg/model"
+	"stream.place/streamplace/pkg/streamplace"
+)
+
+type ManifestBuilder struct {
+	model model.Model
+}
+
+func NewManifestBuilder(model model.Model) *ManifestBuilder {
+	return &ManifestBuilder{
+		model: model,
+	}
+}
+
+func (mb *ManifestBuilder) BuildManifest(ctx context.Context, streamerName string, start int64) (*c2pa.ManifestDefinition, error) {
+	// Start with base manifest
+	mani := obj{
+		"title": fmt.Sprintf("Livestream Segment at %s", aqtime.FromMillis(start)),
+		"assertions": []obj{
+			{
+				"label": "c2pa.actions",
+				"data": obj{
+					"actions": []obj{
+						{"action": "c2pa.created"},
+						{"action": "c2pa.published"},
+					},
+				},
+			},
+			{
+				"label": StreamplaceMetadata,
+				"data": obj{
+					"@context": obj{
+						"dc": "http://purl.org/dc/elements/1.1/",
+						"Iptc4xmpExt": "http://iptc.org/std/Iptc4xmpExt/2008-02-29/",
+						"photoshop": "http://ns.adobe.com/photoshop/1.0/",
+					},
+					"dc:creator": streamerName,
+					// TODO: Add the title of the livestream. This should come from the livestream record.
+					"dc:title":   []string{"livestream"},
+					"dc:date":    []string{aqtime.FromMillis(start).String()},
+				},
+			},
+		},
+	}
+
+	// Add database metadata if available
+	if mb.model != nil {
+		metadata, err := mb.model.GetDefaultMetadata(ctx, streamerName)
+		if err != nil {
+			log.Warn(ctx, "ManifestBuilder: failed to retrieve metadata, using defaults", "error", err, "did", streamerName)
+		} else if metadata != nil {
+			streamplaceMetadata, err := metadata.ToStreamplaceDefaultMetadata()
+			if err != nil {
+				log.Warn(ctx, "ManifestBuilder: failed to convert metadata, using defaults", "error", err, "did", streamerName)
+			} else {
+				mani = mb.enhanceManifestWithMetadata(mani, streamplaceMetadata)
+			}
+		}
+	}
+
+
+	// Convert to C2PA manifest
+	manifestBs, err := json.Marshal(mani)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal manifest: %w", err)
+	}
+
+	var manifest c2pa.ManifestDefinition
+	if err := json.Unmarshal(manifestBs, &manifest); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal manifest: %w", err)
+	}
+
+	return &manifest, nil
+}
+
+func (mb *ManifestBuilder) enhanceManifestWithMetadata(mani obj, metadata *streamplace.DefaultMetadata) obj {
+	if metadata.ContentRights != nil {
+		// TODO: We are currently validating the creator in the ValidateMP4 function to be the streamer DID
+		// if metadata.ContentRights.Creator != nil {
+		//	mani["assertions"].([]obj)[1]["data"].(obj)["dc:creator"] = *metadata.ContentRights.Creator
+		// }
+
+		// Copyright Notice
+		if metadata.ContentRights.CopyrightNotice != nil {
+			mani["assertions"].([]obj)[1]["data"].(obj)["dc:rights"] = *metadata.ContentRights.CopyrightNotice
+		}
+
+		// Copyright Year
+		if metadata.ContentRights.CopyrightYear != nil {
+			mani["assertions"].([]obj)[1]["data"].(obj)["Iptc4xmpExt:CopyrightYear"] = *metadata.ContentRights.CopyrightYear
+		}
+
+		// Credit Line
+		if metadata.ContentRights.CreditLine != nil {
+			mani["assertions"].([]obj)[1]["data"].(obj)["photoshop:Credit"] = *metadata.ContentRights.CreditLine
+		}
+
+		// Linked Enc Rights Expr
+		if metadata.ContentRights.License != nil {
+			mani["assertions"].([]obj)[1]["data"].(obj)["Iptc4xmpExt:LinkedEncRightsExpr"] = *metadata.ContentRights.License
+		}
+	}
+
+	if len(metadata.ContentWarnings) > 0 {
+		mani["assertions"].([]obj)[1]["data"].(obj)["Iptc4xmpExt:ContentWarning"] = metadata.ContentWarnings
+	}
+
+	if metadata.DistributionPolicy != nil {
+		mani["assertions"].([]obj)[1]["data"].(obj)["distributionPolicy"] = metadata.DistributionPolicy
+	}
+
+	return mani
+} 

--- a/pkg/media/manifest_builder.go
+++ b/pkg/media/manifest_builder.go
@@ -12,6 +12,16 @@ import (
 	"stream.place/streamplace/pkg/streamplace"
 )
 
+// ManifestBuilder is responsible for creating C2PA (Content Credentials) manifests
+// for livestream segments.
+// The builder creates manifests that include:
+// - Basic livestream information (title, creator, date)
+// - Content rights and copyright information
+// - Content warnings for sensitive material
+// - Distribution policies
+// - C2PA action history (created, published)
+// The manifest is meant to align closely with the IPTC Video Metadata Recommendations.
+// See https://iptc.org/std/videometadatahub/recommendation/IPTC-VideoMetadataHub-props-Rec_1.6.html
 type ManifestBuilder struct {
 	model model.Model
 }

--- a/pkg/media/media_signer.go
+++ b/pkg/media/media_signer.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto"
 	"crypto/ecdsa"
-	"encoding/json"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -14,12 +13,12 @@ import (
 	"git.stream.place/streamplace/c2pa-go/pkg/c2pa"
 	"go.opentelemetry.io/otel"
 	"stream.place/streamplace/pkg/aqio"
-	"stream.place/streamplace/pkg/aqtime"
 	"stream.place/streamplace/pkg/atproto"
 	"stream.place/streamplace/pkg/config"
 	"stream.place/streamplace/pkg/crypto/aqpub"
 	"stream.place/streamplace/pkg/crypto/signers"
 	"stream.place/streamplace/pkg/log"
+	"stream.place/streamplace/pkg/model"
 	"stream.place/streamplace/pkg/spmetrics"
 )
 
@@ -28,15 +27,19 @@ type MediaSigner interface {
 	Pub() aqpub.Pub
 	Streamer() string
 	DID() string
+	// New method for manifest generation
+	BuildManifest(ctx context.Context, start int64) (*c2pa.ManifestDefinition, error)
 }
 
 type MediaSignerLocal struct {
-	StreamerName string
-	Signer       crypto.Signer
-	AQPub        aqpub.Pub
-	Cert         []byte
-	TAURL        string
-	did          string
+	StreamerName     string
+	Signer           crypto.Signer
+	AQPub            aqpub.Pub
+	Cert             []byte
+	TAURL            string
+	did              string
+	manifestBuilder  *ManifestBuilder
+	Manifest         *c2pa.ManifestDefinition  // Add optional manifest field
 }
 
 func prepareCert(ctx context.Context, cli *config.CLI, signer crypto.Signer) ([]byte, string, error) {
@@ -71,7 +74,7 @@ func prepareCert(ctx context.Context, cli *config.CLI, signer crypto.Signer) ([]
 	return cert, fPath, nil
 }
 
-func MakeMediaSigner(ctx context.Context, cli *config.CLI, streamer string, signer crypto.Signer) (MediaSigner, error) {
+func MakeMediaSigner(ctx context.Context, cli *config.CLI, streamer string, signer crypto.Signer, model model.Model) (MediaSigner, error) {
 	cert, _, err := prepareCert(ctx, cli, signer)
 	if err != nil {
 		return nil, err
@@ -85,12 +88,13 @@ func MakeMediaSigner(ctx context.Context, cli *config.CLI, streamer string, sign
 		return nil, err
 	}
 	return &MediaSignerLocal{
-		Signer:       signer,
-		Cert:         cert,
-		StreamerName: streamer,
-		TAURL:        cli.TAURL,
-		AQPub:        pub,
-		did:          did.DIDKey(),
+		Signer:           signer,
+		Cert:             cert,
+		StreamerName:     streamer,
+		TAURL:            cli.TAURL,
+		AQPub:            pub,
+		did:              did.DIDKey(),
+		manifestBuilder:  NewManifestBuilder(model),
 	}, nil
 }
 
@@ -102,43 +106,20 @@ func (ms *MediaSignerLocal) SignMP4(ctx context.Context, input io.ReadSeeker, st
 	startTime := time.Now()
 	ctx, span := otel.Tracer("signer").Start(ctx, "SignMP4")
 	defer span.End()
-	title := "livestream"
-	mani := obj{
-		"title": fmt.Sprintf("Livestream Segment at %s", aqtime.FromMillis(start)),
-		"assertions": []obj{
-			{
-				"label": "c2pa.actions",
-				"data": obj{
-					"actions": []obj{
-						{"action": "c2pa.created"},
-						{"action": "c2pa.published"},
-					},
-				},
-			},
-			{
-				"label": StreamplaceMetadata,
-				"data": obj{
-					"@context": obj{
-						"dc": "http://purl.org/dc/elements/1.1/",
-					},
-					"dc:creator": ms.StreamerName,
-					"dc:title":   []string{title},
-					"dc:date":    []string{aqtime.FromMillis(start).String()},
-				},
-			},
-		},
+	
+	var manifest *c2pa.ManifestDefinition
+	
+	if ms.Manifest != nil {
+		// Use provided manifest (from external signer)
+		manifest = ms.Manifest
+	} else {
+		// Generate manifest using shared builder
+		var err error
+		manifest, err = ms.BuildManifest(ctx, start)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build manifest: %w", err)
+		}
 	}
-	ctx, span = otel.Tracer("signer").Start(ctx, "SignMP4_MarshalManifest")
-	manifestBs, err := json.Marshal(mani)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal manifest: %w", err)
-	}
-	var manifest c2pa.ManifestDefinition
-	err = json.Unmarshal(manifestBs, &manifest)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal manifest: %w", err)
-	}
-	span.End()
 
 	ctx, span = otel.Tracer("signer").Start(ctx, "SignMP4_GetSigningAlgorithm")
 	alg, err := c2pa.GetSigningAlgorithm(string(c2pa.ES256K))
@@ -148,7 +129,7 @@ func (ms *MediaSignerLocal) SignMP4(ctx context.Context, input io.ReadSeeker, st
 	span.End()
 
 	ctx, span = otel.Tracer("signer").Start(ctx, "SignMP4_NewBuilder")
-	b, err := c2pa.NewBuilder(&manifest, &c2pa.BuilderParams{
+	b, err := c2pa.NewBuilder(manifest, &c2pa.BuilderParams{
 		Cert:      ms.Cert,
 		Signer:    ms.Signer,
 		Algorithm: alg,
@@ -184,4 +165,8 @@ func (ms *MediaSignerLocal) Pub() aqpub.Pub {
 
 func (ms *MediaSignerLocal) DID() string {
 	return ms.did
+}
+
+func (ms *MediaSignerLocal) BuildManifest(ctx context.Context, start int64) (*c2pa.ManifestDefinition, error) {
+	return ms.manifestBuilder.BuildManifest(ctx, ms.StreamerName, start)
 }

--- a/pkg/media/media_signer_ext.go
+++ b/pkg/media/media_signer_ext.go
@@ -5,33 +5,38 @@ import (
 	"context"
 	"crypto"
 	"crypto/ecdsa"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"time"
 
+	"git.stream.place/streamplace/c2pa-go/pkg/c2pa"
 	"github.com/decred/dcrd/dcrec/secp256k1"
 	"github.com/mr-tron/base58"
 	"go.opentelemetry.io/otel"
 	"stream.place/streamplace/pkg/atproto"
 	"stream.place/streamplace/pkg/config"
 	"stream.place/streamplace/pkg/crypto/aqpub"
+	"stream.place/streamplace/pkg/log"
+	"stream.place/streamplace/pkg/model"
 	"stream.place/streamplace/pkg/spmetrics"
 )
 
 type MediaSignerExt struct {
-	cli      *config.CLI
-	signer   crypto.Signer
-	pub      aqpub.Pub
-	certPath string
-	streamer string
-	keyBs    []byte
-	taURL    string
-	did      string
+	cli             *config.CLI
+	signer          crypto.Signer
+	pub             aqpub.Pub
+	certPath        string
+	streamer        string
+	keyBs           []byte
+	taURL           string
+	did             string
+	manifestBuilder *ManifestBuilder
 }
 
-func MakeMediaSignerExt(ctx context.Context, cli *config.CLI, streamer string, keyBs []byte) (MediaSigner, error) {
+func MakeMediaSignerExt(ctx context.Context, cli *config.CLI, streamer string, keyBs []byte, model model.Model) (MediaSigner, error) {
 	key, _ := secp256k1.PrivKeyFromBytes(keyBs)
 	if key == nil {
 		return nil, fmt.Errorf("invalid authorization key (not valid secp256k1)")
@@ -50,14 +55,14 @@ func MakeMediaSignerExt(ctx context.Context, cli *config.CLI, streamer string, k
 		return nil, err
 	}
 	return &MediaSignerExt{
-		// cli:        cli,
-		signer:   signer,
-		certPath: certPath,
-		streamer: streamer,
-		pub:      pub,
-		keyBs:    keyBs,
-		taURL:    cli.TAURL,
-		did:      did.DIDKey(),
+		signer:          signer,
+		certPath:        certPath,
+		streamer:        streamer,
+		pub:             pub,
+		keyBs:           keyBs,
+		taURL:           cli.TAURL,
+		did:             did.DIDKey(),
+		manifestBuilder: NewManifestBuilder(model),
 	}, nil
 }
 
@@ -65,6 +70,21 @@ func (ms *MediaSignerExt) SignMP4(ctx context.Context, input io.ReadSeeker, star
 	startTime := time.Now()
 	_, span := otel.Tracer("signer").Start(ctx, "SignMP4_Ext")
 	defer span.End()
+	
+	// Generate manifest using shared builder
+	manifest, err := ms.BuildManifest(ctx, start)
+	if err != nil {
+		log.Error(ctx, "MediaSignerExt: failed to build manifest", "error", err)
+		return nil, fmt.Errorf("failed to build manifest: %w", err)
+	}
+	
+	// Serialize manifest to JSON
+	manifestJSON, err := json.Marshal(manifest)
+	if err != nil {
+		log.Error(ctx, "MediaSignerExt: failed to serialize manifest", "error", err)
+		return nil, fmt.Errorf("failed to serialize manifest: %w", err)
+	}
+	
 	// Get the path to the current executable
 	execPath, err := os.Executable()
 	if err != nil {
@@ -73,13 +93,14 @@ func (ms *MediaSignerExt) SignMP4(ctx context.Context, input io.ReadSeeker, star
 
 	enc := base58.Encode(ms.keyBs)
 
-	// Prepare command
+	// Prepare command with manifest
 	cmd := exec.Command(execPath, "sign",
 		"--key", enc,
 		"--cert", ms.certPath,
 		"--ta-url", ms.taURL,
 		"--streamer", ms.streamer,
-		"--start-time", fmt.Sprintf("%d", start))
+		"--start-time", fmt.Sprintf("%d", start),
+		"--manifest", string(manifestJSON))
 
 	// overwrite so that our subprocesses don't do their own leak checking
 	cmd.Env = append(os.Environ(), "LD_PRELOAD=")
@@ -109,10 +130,16 @@ func (ms *MediaSignerExt) SignMP4(ctx context.Context, input io.ReadSeeker, star
 
 	// Wait for the command to complete
 	if err := cmd.Wait(); err != nil {
+		log.Error(ctx, "MediaSignerExt: subprocess failed", "error", err, "stderr", stderr.String())
 		return nil, fmt.Errorf("command failed: %w, stderr: %s", err, stderr.String())
 	}
+	
 	spmetrics.SigningDuration.WithLabelValues(ms.streamer).Observe(float64(time.Since(startTime).Milliseconds()))
 	return stdout.Bytes(), nil
+}
+
+func (ms *MediaSignerExt) BuildManifest(ctx context.Context, start int64) (*c2pa.ManifestDefinition, error) {
+	return ms.manifestBuilder.BuildManifest(ctx, ms.streamer, start)
 }
 
 func (ms *MediaSignerExt) Pub() aqpub.Pub {

--- a/pkg/media/media_test.go
+++ b/pkg/media/media_test.go
@@ -48,7 +48,7 @@ func getStaticTestMediaManager(t *testing.T) (*MediaManager, MediaSigner) {
 	}
 	mm, err := MakeMediaManager(context.Background(), cli, signer, &boring.BoringReplicator{}, mod, bus.NewBus(), atsync)
 	require.NoError(t, err)
-	ms, err := MakeMediaSigner(context.Background(), cli, "test-person", signer)
+	ms, err := MakeMediaSigner(context.Background(), cli, "test-person", signer, mod)
 	require.NoError(t, err)
 	return mm, ms
 }

--- a/pkg/media/rtcrec_test.go
+++ b/pkg/media/rtcrec_test.go
@@ -32,7 +32,7 @@ func TestRTCRecording(t *testing.T) {
 		require.NoError(t, err)
 		signer, err := spkey.KeyToSigner(priv)
 		require.NoError(t, err)
-		mediaSigner, err := MakeMediaSigner(ctx, cli, pub.DIDKey(), signer)
+		mediaSigner, err := MakeMediaSigner(ctx, cli, pub.DIDKey(), signer, nil)
 		require.NoError(t, err)
 		// ctx := context.Background()
 		// mm, ms := getStaticTestMediaManager(t)


### PR DESCRIPTION
Manifest builder in the media package does the following:
- Grabs the default metadata from the sqlite database
- Uses it enhance a basic c2pa manifest

The c2pa manifest generated with the manifest builder is then used by the local and external signers to sign segments

There are a couple of TODOs that need to be sorted out later.
1. Currently the existing validate function is validating that the creator ("dc:creator") is the user's DID. If we want to take this from the default metadata record, then  we'll have to change the validation function first.
2. As before, the title is being set to "livestream" across the board. I haven't fixed this yet. This should be taken from announcement record I believe.