### PR TITLE
omit empty records

### DIFF
--- a/js/app/components/content-metadata-form.tsx
+++ b/js/app/components/content-metadata-form.tsx
@@ -283,7 +283,7 @@ export default function ContentMetadataForm({
       };
 
       const metadataPayload = {
-        contentWarnings,
+        ...(contentWarnings.length > 0 && { contentWarnings }),
         distributionPolicy: {
           allowArchive: distributionPolicy.allowArchive,
           ...(distributionPolicy.broadcastExpiry && {

--- a/js/app/features/bluesky/contentMetadataSlice.tsx
+++ b/js/app/features/bluesky/contentMetadataSlice.tsx
@@ -61,9 +61,12 @@ export const contentMetadataSlice = createAppSlice({
         const metadataRecord = {
           $type: "place.stream.default.metadata",
           createdAt: new Date().toISOString(),
-          contentWarnings,
-          contentRights,
+          ...(contentWarnings.length > 0 && { contentWarnings }),
           distributionPolicy,
+          ...(contentRights &&
+            Object.keys(contentRights).length > 0 && {
+              contentRights,
+            }),
         };
 
         const result = await bluesky.pdsAgent.com.atproto.repo.createRecord({
@@ -158,9 +161,12 @@ export const contentMetadataSlice = createAppSlice({
           $type: "place.stream.default.metadata",
           ...(livestreamRef && { livestreamRef }),
           createdAt: new Date().toISOString(),
-          contentWarnings,
-          contentRights,
+          ...(contentWarnings.length > 0 && { contentWarnings }),
           distributionPolicy,
+          ...(contentRights &&
+            Object.keys(contentRights).length > 0 && {
+              contentRights,
+            }),
         };
 
         const result = await bluesky.pdsAgent.com.atproto.repo.putRecord({


### PR DESCRIPTION
- include `contentWarnings` and `contentRights` in the record only when they are populated