### PR TITLE
add license metadata tokens

### DIFF
--- a/js/app/components/content-metadata-form.tsx
+++ b/js/app/components/content-metadata-form.tsx
@@ -89,31 +89,32 @@ const CONTENT_WARNINGS = [
 
 const LICENSE_OPTIONS = [
   { value: "all-rights-reserved", label: "All Rights Reserved" },
-  { value: "cc0", label: "CC0 (Public Domain)" },
-  { value: "cc-by", label: "CC BY" },
-  { value: "cc-by-sa", label: "CC BY-SA" },
-  { value: "cc-by-nc", label: "CC BY-NC" },
-  { value: "cc-by-nc-sa", label: "CC BY-NC-SA" },
-  { value: "cc-by-nd", label: "CC BY-ND" },
-  { value: "cc-by-nc-nd", label: "CC BY-NC-ND" },
+  { value: "cc0_1__0", label: "CC0 (Public Domain) 1.0" },
+  { value: "cc-by_4__0", label: "CC BY 4.0" },
+  { value: "cc-by-sa_4__0", label: "CC BY-SA 4.0" },
+  { value: "cc-by-nc_4__0", label: "CC BY-NC 4.0" },
+  { value: "cc-by-nc-sa_4__0", label: "CC BY-NC-SA 4.0" },
+  { value: "cc-by-nd_4__0", label: "CC BY-ND 4.0" },
+  { value: "cc-by-nc-nd_4__0", label: "CC BY-NC-ND 4.0" },
   { value: "custom", label: "Custom License" },
 ];
 
 const LICENSE_DESCRIPTIONS: Record<string, string> = {
   "all-rights-reserved":
     "All rights reserved to the creator — others cannot use, modify, or share without explicit authorization.",
-  cc0: "Public domain dedication. You waive all copyright and related rights where possible. Others may copy, modify, distribute, or perform your work for any purpose without attribution.",
-  "cc-by":
+  cc0_1__0:
+    "Public domain dedication. You waive all copyright and related rights where possible. Others may copy, modify, distribute, or perform your work for any purpose without attribution.",
+  "cc-by_4__0":
     "Attribution required. Others may copy, distribute, remix, and build upon your work, even commercially, if they credit you.",
-  "cc-by-sa":
+  "cc-by-sa_4__0":
     "Attribution + share-alike. Others may adapt and build upon your work, even commercially, if they credit you and license their new creations under identical terms.",
-  "cc-by-nc":
+  "cc-by-nc_4__0":
     "Attribution + non-commercial. Others may adapt and build upon your work for non-commercial purposes only, and must credit you.",
-  "cc-by-nc-sa":
+  "cc-by-nc-sa_4__0":
     "Attribution + non-commercial + share-alike. Others may adapt and build upon your work for non-commercial purposes only, must credit you, and must license their new creations under identical terms.",
-  "cc-by-nd":
+  "cc-by-nd_4__0":
     "Attribution + no derivatives. Others may reuse your work, even commercially, but it must remain unchanged and you must be credited.",
-  "cc-by-nc-nd":
+  "cc-by-nc-nd_4__0":
     "Attribution + non-commercial + no derivatives. Others may download and share your work with credit, but cannot change it or use it commercially.",
   custom:
     "Custom license. Define your own terms for how others can use, adapt, or share your content.",

--- a/js/app/components/content-metadata-form.tsx
+++ b/js/app/components/content-metadata-form.tsx
@@ -96,7 +96,7 @@ const LICENSE_OPTIONS = [
     value: "place.stream.default.metadata#cc0_1__0",
     label: "CC0 (Public Domain) 1.0",
   },
-  { value: "place.stream.default.metadata#cc-by_4_00", label: "CC BY 4.0" },
+  { value: "place.stream.default.metadata#cc-by_4__0", label: "CC BY 4.0" },
   {
     value: "place.stream.default.metadata#cc-by-sa_4__0",
     label: "CC BY-SA 4.0",
@@ -125,7 +125,7 @@ const LICENSE_DESCRIPTIONS: Record<string, string> = {
     "All rights reserved to the creator — others cannot use, modify, or share without explicit authorization.",
   "place.stream.default.metadata#cc0_1__0":
     "Public domain dedication. You waive all copyright and related rights where possible. Others may copy, modify, distribute, or perform your work for any purpose without attribution.",
-  "place.stream.default.metadata#cc-by_4_00":
+  "place.stream.default.metadata#cc-by_4__0":
     "Attribution required. Others may copy, distribute, remix, and build upon your work, even commercially, if they credit you.",
   "place.stream.default.metadata#cc-by-sa_4__0":
     "Attribution + share-alike. Others may adapt and build upon your work, even commercially, if they credit you and license their new creations under identical terms.",

--- a/js/app/components/content-metadata-form.tsx
+++ b/js/app/components/content-metadata-form.tsx
@@ -102,7 +102,7 @@ const LICENSE_OPTIONS = [
 const LICENSE_DESCRIPTIONS: Record<string, string> = {
   "all-rights-reserved":
     "All rights reserved to the creator — others cannot use, modify, or share without explicit authorization.",
-  cc0_1__0:
+  "cc0_1__0":
     "Public domain dedication. You waive all copyright and related rights where possible. Others may copy, modify, distribute, or perform your work for any purpose without attribution.",
   "cc-by_4__0":
     "Attribution required. Others may copy, distribute, remix, and build upon your work, even commercially, if they credit you.",

--- a/js/app/components/content-metadata-form.tsx
+++ b/js/app/components/content-metadata-form.tsx
@@ -88,35 +88,56 @@ const CONTENT_WARNINGS = [
 // No predefined options - just optional expiry date-time picker
 
 const LICENSE_OPTIONS = [
-  { value: "all-rights-reserved", label: "All Rights Reserved" },
-  { value: "cc0_1__0", label: "CC0 (Public Domain) 1.0" },
-  { value: "cc-by_4__0", label: "CC BY 4.0" },
-  { value: "cc-by-sa_4__0", label: "CC BY-SA 4.0" },
-  { value: "cc-by-nc_4__0", label: "CC BY-NC 4.0" },
-  { value: "cc-by-nc-sa_4__0", label: "CC BY-NC-SA 4.0" },
-  { value: "cc-by-nd_4__0", label: "CC BY-ND 4.0" },
-  { value: "cc-by-nc-nd_4__0", label: "CC BY-NC-ND 4.0" },
-  { value: "custom", label: "Custom License" },
+  {
+    value: "place.stream.default.metadata#all-rights-reserved",
+    label: "All Rights Reserved",
+  },
+  {
+    value: "place.stream.default.metadata#cc0_1__0",
+    label: "CC0 (Public Domain) 1.0",
+  },
+  { value: "place.stream.default.metadata#cc-by_4_00", label: "CC BY 4.0" },
+  {
+    value: "place.stream.default.metadata#cc-by-sa_4__0",
+    label: "CC BY-SA 4.0",
+  },
+  {
+    value: "place.stream.default.metadata#cc-by-nc_4__0",
+    label: "CC BY-NC 4.0",
+  },
+  {
+    value: "place.stream.default.metadata#cc-by-nc-sa_4__0",
+    label: "CC BY-NC-SA 4.0",
+  },
+  {
+    value: "place.stream.default.metadata#cc-by-nd_4__0",
+    label: "CC BY-ND 4.0",
+  },
+  {
+    value: "place.stream.default.metadata#cc-by-nc-nd_4__0",
+    label: "CC BY-NC-ND 4.0",
+  },
+  { value: "place.stream.default.metadata#custom", label: "Custom License" },
 ];
 
 const LICENSE_DESCRIPTIONS: Record<string, string> = {
-  "all-rights-reserved":
+  "place.stream.default.metadata#all-rights-reserved":
     "All rights reserved to the creator — others cannot use, modify, or share without explicit authorization.",
-  "cc0_1__0":
+  "place.stream.default.metadata#cc0_1__0":
     "Public domain dedication. You waive all copyright and related rights where possible. Others may copy, modify, distribute, or perform your work for any purpose without attribution.",
-  "cc-by_4__0":
+  "place.stream.default.metadata#cc-by_4_00":
     "Attribution required. Others may copy, distribute, remix, and build upon your work, even commercially, if they credit you.",
-  "cc-by-sa_4__0":
+  "place.stream.default.metadata#cc-by-sa_4__0":
     "Attribution + share-alike. Others may adapt and build upon your work, even commercially, if they credit you and license their new creations under identical terms.",
-  "cc-by-nc_4__0":
+  "place.stream.default.metadata#cc-by-nc_4__0":
     "Attribution + non-commercial. Others may adapt and build upon your work for non-commercial purposes only, and must credit you.",
-  "cc-by-nc-sa_4__0":
+  "place.stream.default.metadata#cc-by-nc-sa_4__0":
     "Attribution + non-commercial + share-alike. Others may adapt and build upon your work for non-commercial purposes only, must credit you, and must license their new creations under identical terms.",
-  "cc-by-nd_4__0":
+  "place.stream.default.metadata#cc-by-nd_4__0":
     "Attribution + no derivatives. Others may reuse your work, even commercially, but it must remain unchanged and you must be credited.",
-  "cc-by-nc-nd_4__0":
+  "place.stream.default.metadata#cc-by-nc-nd_4__0":
     "Attribution + non-commercial + no derivatives. Others may download and share your work with credit, but cannot change it or use it commercially.",
-  custom:
+  "place.stream.default.metadata#custom":
     "Custom license. Define your own terms for how others can use, adapt, or share your content.",
 };
 
@@ -248,7 +269,7 @@ export default function ContentMetadataForm({
           creator: record.contentRights.creator || "",
           copyrightNotice: record.contentRights.copyrightNotice || "",
           copyrightYear: record.contentRights.copyrightYear || "",
-          license: record.contentRights.license || "all-rights-reserved",
+          license: record.contentRights.license || "",
           creditLine: record.contentRights.creditLine || "",
           customLicense: record.contentRights.customLicense || "",
         };
@@ -263,9 +284,7 @@ export default function ContentMetadataForm({
           allowArchive: record.distributionPolicy?.allowArchive ?? true,
           broadcastExpiry: record.distributionPolicy?.broadcastExpiry,
         },
-        contentRights: record.contentRights || {
-          license: "all-rights-reserved",
-        },
+        contentRights: record.contentRights || {},
       };
       onMetadataChange(metadata);
 
@@ -805,7 +824,7 @@ export default function ContentMetadataForm({
                     value={selectedLicense || undefined}
                     onValueChange={(value) => {
                       setSelectedLicense(value);
-                      if (value !== "custom") {
+                      if (value !== "place.stream.default.metadata#custom") {
                         handleContentRightsChange({ license: value });
                       }
                     }}
@@ -905,7 +924,7 @@ export default function ContentMetadataForm({
                   )}
                 </YStack>
 
-                {selectedLicense === "custom" && (
+                {selectedLicense === "place.stream.default.metadata#custom" && (
                   <YStack gap="$0.5">
                     <Label fontSize="$1" fontWeight="500">
                       Custom License
@@ -915,7 +934,7 @@ export default function ContentMetadataForm({
                       value={contentRights.customLicense || ""}
                       onChangeText={(text) =>
                         handleContentRightsChange({
-                          license: "custom",
+                          license: "place.stream.default.metadata#custom",
                           customLicense: text,
                         })
                       }

--- a/js/app/components/content-metadata-form.tsx
+++ b/js/app/components/content-metadata-form.tsx
@@ -268,7 +268,7 @@ export default function ContentMetadataForm({
         const rights = {
           creator: record.contentRights.creator || "",
           copyrightNotice: record.contentRights.copyrightNotice || "",
-          copyrightYear: record.contentRights.copyrightYear || "",
+          copyrightYear: record.contentRights.copyrightYear || undefined,
           license: record.contentRights.license || "",
           creditLine: record.contentRights.creditLine || "",
           customLicense: record.contentRights.customLicense || "",

--- a/js/docs/src/content/docs/lex-reference/default/place-stream-default-metadata.md
+++ b/js/docs/src/content/docs/lex-reference/default/place-stream-default-metadata.md
@@ -38,13 +38,13 @@ Content rights and attribution information.
 
 **Properties:**
 
-| Name              | Type      | Req'd | Description                      | Constraints |
-| ----------------- | --------- | ----- | -------------------------------- | ----------- |
-| `creator`         | `string`  | ❌    | Name of the creator of the work. |             |
-| `copyrightNotice` | `string`  | ❌    | Copyright notice for the work.   |             |
-| `copyrightYear`   | `integer` | ❌    | Year of creation or publication. |             |
-| `license`         | `string`  | ❌    | License URL or identifier.       |             |
-| `creditLine`      | `string`  | ❌    | Credit line for the work.        |             |
+| Name              | Type      | Req'd | Description                      | Constraints                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| ----------------- | --------- | ----- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `creator`         | `string`  | ❌    | Name of the creator of the work. |                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `copyrightNotice` | `string`  | ❌    | Copyright notice for the work.   |                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `copyrightYear`   | `integer` | ❌    | Year of creation or publication. |                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `license`         | `string`  | ❌    | License URL or identifier.       | Known Values: `place.stream.default.metadata#all-rights-reserved`, `place.stream.default.metadata#cc0_1__0`, `place.stream.default.metadata#cc-by_4_00`, `place.stream.default.metadata#cc-by-sa_4__0`, `place.stream.default.metadata#cc-by-nc_4__0`, `place.stream.default.metadata#cc-by-nc-sa_4__0`, `place.stream.default.metadata#cc-by-nd_4__0`, `place.stream.default.metadata#cc-by-nc-nd_4__0`, `place.stream.default.metadata#custom` |
+| `creditLine`      | `string`  | ❌    | Credit line for the work.        |                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 
 ---
 
@@ -175,6 +175,108 @@ violence.
 
 ---
 
+<a name="allrightsreserved"></a>
+
+### `all-rights-reserved`
+
+**Type:** `token`
+
+All rights reserved to the creator — others cannot use, modify, or share without
+explicit authorization.
+
+---
+
+<a name="cc010"></a>
+
+### `cc0_1__0`
+
+**Type:** `token`
+
+Public domain dedication. You waive all copyright and related rights where
+possible. Others may copy, modify, distribute, or perform your work for any
+purpose without attribution.
+
+---
+
+<a name="ccby400"></a>
+
+### `cc-by_4_00`
+
+**Type:** `token`
+
+Attribution required. Others may copy, distribute, remix, and build upon your
+work, even commercially, if they credit you.
+
+---
+
+<a name="ccbysa40"></a>
+
+### `cc-by-sa_4__0`
+
+**Type:** `token`
+
+Attribution + share-alike. Others may adapt and build upon your work, even
+commercially, if they credit you and license their new creations under identical
+terms.
+
+---
+
+<a name="ccbync40"></a>
+
+### `cc-by-nc_4__0`
+
+**Type:** `token`
+
+Attribution + non-commercial. Others may adapt and build upon your work for
+non-commercial purposes only, and must credit you.
+
+---
+
+<a name="ccbyncsa40"></a>
+
+### `cc-by-nc-sa_4__0`
+
+**Type:** `token`
+
+Attribution + non-commercial + share-alike. Others may adapt and build upon your
+work for non-commercial purposes only, must credit you, and must license their
+new creations under identical terms.
+
+---
+
+<a name="ccbynd40"></a>
+
+### `cc-by-nd_4__0`
+
+**Type:** `token`
+
+Attribution + no derivatives. Others may reuse your work, even commercially, but
+it must remain unchanged and you must be credited.
+
+---
+
+<a name="ccbyncnd40"></a>
+
+### `cc-by-nc-nd_4__0`
+
+**Type:** `token`
+
+Attribution + non-commercial + no derivatives. Others may download and share
+your work with credit, but cannot change it or use it commercially.
+
+---
+
+<a name="custom"></a>
+
+### `custom`
+
+**Type:** `token`
+
+Custom license. Define your own terms for how others can use, adapt, or share
+your content.
+
+---
+
 ## Lexicon Source
 
 ```json
@@ -237,7 +339,18 @@ violence.
         },
         "license": {
           "type": "string",
-          "description": "License URL or identifier."
+          "description": "License URL or identifier.",
+          "knownValues": [
+            "place.stream.default.metadata#all-rights-reserved",
+            "place.stream.default.metadata#cc0_1__0",
+            "place.stream.default.metadata#cc-by_4_00",
+            "place.stream.default.metadata#cc-by-sa_4__0",
+            "place.stream.default.metadata#cc-by-nc_4__0",
+            "place.stream.default.metadata#cc-by-nc-sa_4__0",
+            "place.stream.default.metadata#cc-by-nd_4__0",
+            "place.stream.default.metadata#cc-by-nc-nd_4__0",
+            "place.stream.default.metadata#custom"
+          ]
         },
         "creditLine": {
           "type": "string",
@@ -299,6 +412,42 @@ violence.
     "violence": {
       "type": "token",
       "description": "The content could be perceived as offensive due to the discussion or display of violence."
+    },
+    "all-rights-reserved": {
+      "type": "token",
+      "description": "All rights reserved to the creator — others cannot use, modify, or share without explicit authorization."
+    },
+    "cc0_1__0": {
+      "type": "token",
+      "description": "Public domain dedication. You waive all copyright and related rights where possible. Others may copy, modify, distribute, or perform your work for any purpose without attribution."
+    },
+    "cc-by_4_00": {
+      "type": "token",
+      "description": "Attribution required. Others may copy, distribute, remix, and build upon your work, even commercially, if they credit you."
+    },
+    "cc-by-sa_4__0": {
+      "type": "token",
+      "description": "Attribution + share-alike. Others may adapt and build upon your work, even commercially, if they credit you and license their new creations under identical terms."
+    },
+    "cc-by-nc_4__0": {
+      "type": "token",
+      "description": "Attribution + non-commercial. Others may adapt and build upon your work for non-commercial purposes only, and must credit you."
+    },
+    "cc-by-nc-sa_4__0": {
+      "type": "token",
+      "description": "Attribution + non-commercial + share-alike. Others may adapt and build upon your work for non-commercial purposes only, must credit you, and must license their new creations under identical terms."
+    },
+    "cc-by-nd_4__0": {
+      "type": "token",
+      "description": "Attribution + no derivatives. Others may reuse your work, even commercially, but it must remain unchanged and you must be credited."
+    },
+    "cc-by-nc-nd_4__0": {
+      "type": "token",
+      "description": "Attribution + non-commercial + no derivatives. Others may download and share your work with credit, but cannot change it or use it commercially."
+    },
+    "custom": {
+      "type": "token",
+      "description": "Custom license. Define your own terms for how others can use, adapt, or share your content."
     }
   }
 }

--- a/lexicons/place/stream/default/metadata.json
+++ b/lexicons/place/stream/default/metadata.json
@@ -57,7 +57,18 @@
         },
         "license": {
           "type": "string",
-          "description": "License URL or identifier."
+          "description": "License URL or identifier.",
+          "knownValues": [
+            "place.stream.default.metadata#all-rights-reserved",
+            "place.stream.default.metadata#cc0_1__0",
+            "place.stream.default.metadata#cc-by_4_00",
+            "place.stream.default.metadata#cc-by-sa_4__0",
+            "place.stream.default.metadata#cc-by-nc_4__0",
+            "place.stream.default.metadata#cc-by-nc-sa_4__0",
+            "place.stream.default.metadata#cc-by-nd_4__0",
+            "place.stream.default.metadata#cc-by-nc-nd_4__0",
+            "place.stream.default.metadata#custom"
+          ]
         },
         "creditLine": {
           "type": "string",
@@ -119,6 +130,42 @@
     "violence": {
       "type": "token",
       "description": "The content could be perceived as offensive due to the discussion or display of violence."
+    },
+    "all-rights-reserved": {
+      "type": "token",
+      "description": "All rights reserved to the creator — others cannot use, modify, or share without explicit authorization."
+    },
+    "cc0_1__0": {
+      "type": "token",
+      "description": "Public domain dedication. You waive all copyright and related rights where possible. Others may copy, modify, distribute, or perform your work for any purpose without attribution."
+    },
+    "cc-by_4_00": {
+      "type": "token",
+      "description": "Attribution required. Others may copy, distribute, remix, and build upon your work, even commercially, if they credit you."
+    },
+    "cc-by-sa_4__0": {
+      "type": "token",
+      "description": "Attribution + share-alike. Others may adapt and build upon your work, even commercially, if they credit you and license their new creations under identical terms."
+    },
+    "cc-by-nc_4__0": {
+      "type": "token",
+      "description": "Attribution + non-commercial. Others may adapt and build upon your work for non-commercial purposes only, and must credit you."
+    },
+    "cc-by-nc-sa_4__0": {
+      "type": "token",
+      "description": "Attribution + non-commercial + share-alike. Others may adapt and build upon your work for non-commercial purposes only, must credit you, and must license their new creations under identical terms."
+    },
+    "cc-by-nd_4__0": {
+      "type": "token",
+      "description": "Attribution + no derivatives. Others may reuse your work, even commercially, but it must remain unchanged and you must be credited."
+    },
+    "cc-by-nc-nd_4__0": {
+      "type": "token",
+      "description": "Attribution + non-commercial + no derivatives. Others may download and share your work with credit, but cannot change it or use it commercially."
+    },
+    "custom": {
+      "type": "token",
+      "description": "Custom license. Define your own terms for how others can use, adapt, or share your content."
     }
   }
 }


### PR DESCRIPTION
- uses `knownValues` to set license info as `token`
- includes license version, description and regenerated lexicon
- edit FE to create license records in the following format ->  `place.stream.default.metadata#cc0_1__0`
