### PR TITLE
feat: node content filtering

### DIFF
--- a/content-filters-example.yaml
+++ b/content-filters-example.yaml
@@ -1,0 +1,23 @@
+# Example content filters configuration for Streamplace
+# This file can be used with the --content-filters flag
+
+# Content warnings filtering
+content_warnings:
+  enabled: true
+  blocked_warnings:
+    - "cwarn:violence"
+    - "cwarn:nudity"
+    - "cwarn:death"
+    # Add more warnings as needed:
+    # - "cwarn:drugUse"
+    # - "cwarn:fantasyViolence"
+    # - "cwarn:flashingLights"
+    # - "cwarn:language"
+    # - "cwarn:PII"
+    # - "cwarn:sexuality"
+    # - "cwarn:suffering"
+
+# Distribution policy filtering
+distribution_policy:
+  enabled: true
+  # When enabled, streams with expired broadcast permissions will be filtered

--- a/pkg/cmd/streamplace.go
+++ b/pkg/cmd/streamplace.go
@@ -151,6 +151,12 @@ func start(build *config.BuildFlags, platformJobs []jobFunc) error {
 	if err != nil {
 		return err
 	}
+
+	// Load content filters after CLI parsing
+	if err := cli.LoadContentFilters(); err != nil {
+		return fmt.Errorf("failed to load content filters: %w", err)
+	}
+
 	err = flag.CommandLine.Parse(nil)
 	if err != nil {
 		return err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/peterbourgon/ff/v3"
+	"gopkg.in/yaml.v3"
 	"stream.place/streamplace/pkg/aqtime"
 	"stream.place/streamplace/pkg/constants"
 	"stream.place/streamplace/pkg/crypto/aqpub"
@@ -109,6 +110,19 @@ type CLI struct {
 	AndroidCertFingerprint string
 	Labelers               []string
 	AtprotoDID             string
+	ContentFiltersPath     string
+	ContentFilters         *ContentFilters
+}
+
+// ContentFilters represents the content filtering configuration
+type ContentFilters struct {
+	ContentWarnings struct {
+		Enabled         bool     `yaml:"enabled"`
+		BlockedWarnings []string `yaml:"blocked_warnings"`
+	} `yaml:"content_warnings"`
+	DistributionPolicy struct {
+		Enabled bool `yaml:"enabled"`
+	} `yaml:"distribution_policy"`
 }
 
 func (cli *CLI) NewFlagSet(name string) *flag.FlagSet {
@@ -168,6 +182,7 @@ func (cli *CLI) NewFlagSet(name string) *flag.FlagSet {
 	fs.StringVar(&cli.AndroidCertFingerprint, "android-cert-fingerprint", "", "android cert fingerprint for deep linking")
 	cli.StringSliceFlag(fs, &cli.Labelers, "labelers", "", "did of labelers that this instance should subscribe to")
 	fs.StringVar(&cli.AtprotoDID, "atproto-did", "", "atproto did to respond to on /.well-known/atproto-did (default did:web:PUBLIC_HOST)")
+	fs.StringVar(&cli.ContentFiltersPath, "content-filters", "", "path to YAML file with content filtering rules")
 
 	if runtime.GOOS == "linux" {
 		fs.BoolVar(&cli.NoMist, "no-mist", true, "Disable MistServer")
@@ -176,6 +191,26 @@ func (cli *CLI) NewFlagSet(name string) *flag.FlagSet {
 		fs.IntVar(&cli.MistHTTPPort, "mist-http-port", 18080, "MistServer HTTP port (internal use only)")
 	}
 	return fs
+}
+
+// LoadContentFilters loads content filtering configuration from YAML file
+func (cli *CLI) LoadContentFilters() error {
+	if cli.ContentFiltersPath == "" {
+		return nil
+	}
+	
+	data, err := os.ReadFile(cli.ContentFiltersPath)
+	if err != nil {
+		return fmt.Errorf("failed to read content filters file: %w", err)
+	}
+	
+	var filters ContentFilters
+	if err := yaml.Unmarshal(data, &filters); err != nil {
+		return fmt.Errorf("failed to parse content filters YAML: %w", err)
+	}
+	
+	cli.ContentFilters = &filters
+	return nil
 }
 
 var StreamplaceSchemePrefix = "streamplace://"

--- a/pkg/media/media.go
+++ b/pkg/media/media.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/pion/interceptor"
@@ -175,9 +176,16 @@ type ExpandedSchemaOrg []struct {
 }
 
 type SegmentMetadata struct {
-	StartTime aqtime.AQTime
-	Title     string
-	Creator   string
+	StartTime           aqtime.AQTime
+	Title               string
+	Creator             string
+	ContentWarnings     []string           // Add this field
+	DistributionPolicy  *DistributionPolicy // Add this field
+}
+
+// DistributionPolicy represents distribution policy information
+type DistributionPolicy struct {
+	ExpiresAt *time.Time
 }
 
 var ErrInvalidMetadata = errors.New("invalid segment metadata")
@@ -227,10 +235,99 @@ func ParseSegmentAssertions(ctx context.Context, mani *manifeststore.Manifest) (
 	if err != nil {
 		return nil, err
 	}
+	
+	contentWarnings := extractContentWarnings(mani)
+	distributionPolicy := extractDistributionPolicy(mani)
+	
 	out := SegmentMetadata{
-		StartTime: start,
-		Title:     meta.Title[0].Value,
-		Creator:   meta.Creator[0].Value,
+		StartTime:           start,
+		Title:               meta.Title[0].Value,
+		Creator:             meta.Creator[0].Value,
+		ContentWarnings:     contentWarnings,
+		DistributionPolicy:  distributionPolicy,
 	}
 	return &out, nil
+}
+
+// TODO: We should be using the schemas for better validation
+func extractContentWarnings(mani *manifeststore.Manifest) []string {
+	ass := findAssertion(mani, StreamplaceMetadata)
+	if ass == nil {
+		return nil
+	}
+	
+	data, ok := ass.Data.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	
+	warnings, ok := data["Iptc4xmpExt:ContentWarning"]
+	if !ok {
+		return nil
+	}
+	
+	warningList, ok := warnings.([]interface{})
+	if !ok {
+		return nil
+	}
+	
+	result := make([]string, 0, len(warningList))
+	for _, warning := range warningList {
+		if warningStr, ok := warning.(string); ok {
+			result = append(result, warningStr)
+		}
+	}
+	
+	return result
+}
+
+func extractDistributionPolicy(mani *manifeststore.Manifest) *DistributionPolicy {
+	ass := findAssertion(mani, StreamplaceMetadata)
+	if ass == nil {
+		return nil
+	}
+	
+	data, ok := ass.Data.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	
+	policy, ok := data["distributionPolicy"]
+	if !ok {
+		return nil
+	}
+	
+	policyMap, ok := policy.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	
+	expiry, ok := policyMap["broadcastExpiry"]
+	if !ok {
+		return nil
+	}
+	
+	expiryStr, ok := expiry.(string)
+	if !ok {
+		return nil
+	}
+	
+	expiryTime, err := time.Parse(time.RFC3339, expiryStr)
+	if err != nil {
+		return nil
+	}
+	
+	return &DistributionPolicy{
+		ExpiresAt: &expiryTime,
+	}
+}
+
+// findAssertion finds an assertion by label
+func findAssertion(mani *manifeststore.Manifest, label string) *manifeststore.ManifestAssertion {
+	for _, a := range mani.Assertions {
+		if a.Label == label {
+			return &a
+		}
+	}
+	return nil
 }

--- a/pkg/media/validate.go
+++ b/pkg/media/validate.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"go.opentelemetry.io/otel"
 	"stream.place/streamplace/pkg/aqtime"
@@ -43,6 +44,14 @@ func (mm *MediaManager) ValidateMP4(ctx context.Context, input io.Reader) error 
 	if err != nil {
 		return err
 	}
+	
+	// Apply content filtering after metadata is parsed
+	if mm.cli.ContentFilters != nil {
+		if err := mm.applyContentFilters(ctx, meta); err != nil {
+			return err
+		}
+	}
+	
 	// special case for test signers that are only signed with a key
 	var repoDID string
 	var signingKeyDID string
@@ -101,4 +110,48 @@ func (mm *MediaManager) ValidateMP4(ctx context.Context, input io.Reader) error 
 	aqt := aqtime.FromTime(meta.StartTime.Time())
 	log.Log(ctx, "successfully ingested segment", "user", repoDID, "signingKey", signingKeyDID, "timestamp", aqt.FileSafeString(), "segmentID", *mani.Label)
 	return nil
+}
+
+// applyContentFilters applies content filtering based on configured rules
+func (mm *MediaManager) applyContentFilters(ctx context.Context, meta *SegmentMetadata) error {
+	// Check content warnings (if enabled)
+	if mm.cli.ContentFilters.ContentWarnings.Enabled {
+		for _, warning := range meta.ContentWarnings {
+			if mm.isWarningBlocked(warning) {
+				reason := fmt.Sprintf("content warning blocked: %s", warning)
+				log.Log(ctx, "content filtered", 
+					"reason", reason, 
+					"filter_type", "content_warning",
+					"creator", meta.Creator,
+					"warning", warning)
+				return fmt.Errorf("content filtered: %s", reason)
+			}
+		}
+	}
+	
+	// Check distribution policy (if enabled)
+	if mm.cli.ContentFilters.DistributionPolicy.Enabled && meta.DistributionPolicy != nil {
+		if meta.DistributionPolicy.ExpiresAt != nil && time.Now().After(*meta.DistributionPolicy.ExpiresAt) {
+			reason := fmt.Sprintf("distribution policy expired: %s", meta.DistributionPolicy.ExpiresAt)
+			log.Log(ctx, "content filtered", 
+				"reason", reason, 
+				"filter_type", "distribution_policy",
+				"creator", meta.Creator,
+				"expires_at", meta.DistributionPolicy.ExpiresAt)
+			return fmt.Errorf("content filtered: %s", reason)
+		}
+	}
+	
+	return nil
+}
+
+// isWarningBlocked checks if a content warning is in the blocked list
+func (mm *MediaManager) isWarningBlocked(warning string) bool {
+	// Direct string comparison - no mapping needed
+	for _, blocked := range mm.cli.ContentFilters.ContentWarnings.BlockedWarnings {
+		if warning == blocked {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Allows filtering by two types of content filters
- content warnings
- distribution policy

Node is configured using a content filters YAML file (`./streamplace --content-filters /path/to/yaml`). I've included an example file for reference. 