### PR TITLE
fix typo in license and generate docs

### DIFF
--- a/js/docs/src/content/docs/lex-reference/default/place-stream-default-metadata.md
+++ b/js/docs/src/content/docs/lex-reference/default/place-stream-default-metadata.md
@@ -38,13 +38,13 @@ Content rights and attribution information.
 
 **Properties:**
 
-| Name              | Type      | Req'd | Description                      | Constraints                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| ----------------- | --------- | ----- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `creator`         | `string`  | ❌    | Name of the creator of the work. |                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| `copyrightNotice` | `string`  | ❌    | Copyright notice for the work.   |                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| `copyrightYear`   | `integer` | ❌    | Year of creation or publication. |                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| `license`         | `string`  | ❌    | License URL or identifier.       | Known Values: `place.stream.default.metadata#all-rights-reserved`, `place.stream.default.metadata#cc0_1__0`, `place.stream.default.metadata#cc-by_4_00`, `place.stream.default.metadata#cc-by-sa_4__0`, `place.stream.default.metadata#cc-by-nc_4__0`, `place.stream.default.metadata#cc-by-nc-sa_4__0`, `place.stream.default.metadata#cc-by-nd_4__0`, `place.stream.default.metadata#cc-by-nc-nd_4__0`, `place.stream.default.metadata#custom` |
-| `creditLine`      | `string`  | ❌    | Credit line for the work.        |                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| Name              | Type      | Req'd | Description                      | Constraints                                                                                                                                                                                                                                                                                                                                                                                              |
+| ----------------- | --------- | ----- | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `creator`         | `string`  | ❌    | Name of the creator of the work. |                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `copyrightNotice` | `string`  | ❌    | Copyright notice for the work.   |                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `copyrightYear`   | `integer` | ❌    | Year of creation or publication. |                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `license`         | `string`  | ❌    | License URL or identifier.       | Known Values: `place.stream.default.metadata#all-rights-reserved`, `place.stream.default.metadata#cc0_1__0`, `place.stream.default.metadata#cc-by_4_00`, `place.stream.default.metadata#cc-by-sa_4__0`, `place.stream.default.metadata#cc-by-nc_4__0`, `place.stream.default.metadata#cc-by-nc-sa_4__0`, `place.stream.default.metadata#cc-by-nd_4__0`, `place.stream.default.metadata#cc-by-nc-nd_4__0` |
+| `creditLine`      | `string`  | ❌    | Credit line for the work.        |                                                                                                                                                                                                                                                                                                                                                                                                          |
 
 ---
 
@@ -266,17 +266,6 @@ your work with credit, but cannot change it or use it commercially.
 
 ---
 
-<a name="custom"></a>
-
-### `custom`
-
-**Type:** `token`
-
-Custom license. Define your own terms for how others can use, adapt, or share
-your content.
-
----
-
 ## Lexicon Source
 
 ```json
@@ -348,8 +337,7 @@ your content.
             "place.stream.default.metadata#cc-by-nc_4__0",
             "place.stream.default.metadata#cc-by-nc-sa_4__0",
             "place.stream.default.metadata#cc-by-nd_4__0",
-            "place.stream.default.metadata#cc-by-nc-nd_4__0",
-            "place.stream.default.metadata#custom"
+            "place.stream.default.metadata#cc-by-nc-nd_4__0"
           ]
         },
         "creditLine": {
@@ -444,10 +432,6 @@ your content.
     "cc-by-nc-nd_4__0": {
       "type": "token",
       "description": "Attribution + non-commercial + no derivatives. Others may download and share your work with credit, but cannot change it or use it commercially."
-    },
-    "custom": {
-      "type": "token",
-      "description": "Custom license. Define your own terms for how others can use, adapt, or share your content."
     }
   }
 }

--- a/js/docs/src/content/docs/lex-reference/default/place-stream-default-metadata.md
+++ b/js/docs/src/content/docs/lex-reference/default/place-stream-default-metadata.md
@@ -198,9 +198,9 @@ purpose without attribution.
 
 ---
 
-<a name="ccby400"></a>
+<a name="ccby40"></a>
 
-### `cc-by_4_00`
+### `cc-by_4__0`
 
 **Type:** `token`
 
@@ -421,7 +421,7 @@ your content.
       "type": "token",
       "description": "Public domain dedication. You waive all copyright and related rights where possible. Others may copy, modify, distribute, or perform your work for any purpose without attribution."
     },
-    "cc-by_4_00": {
+    "cc-by_4__0": {
       "type": "token",
       "description": "Attribution required. Others may copy, distribute, remix, and build upon your work, even commercially, if they credit you."
     },

--- a/lexicons/place/stream/default/metadata.json
+++ b/lexicons/place/stream/default/metadata.json
@@ -66,8 +66,7 @@
             "place.stream.default.metadata#cc-by-nc_4__0",
             "place.stream.default.metadata#cc-by-nc-sa_4__0",
             "place.stream.default.metadata#cc-by-nd_4__0",
-            "place.stream.default.metadata#cc-by-nc-nd_4__0",
-            "place.stream.default.metadata#custom"
+            "place.stream.default.metadata#cc-by-nc-nd_4__0"
           ]
         },
         "creditLine": {
@@ -162,10 +161,6 @@
     "cc-by-nc-nd_4__0": {
       "type": "token",
       "description": "Attribution + non-commercial + no derivatives. Others may download and share your work with credit, but cannot change it or use it commercially."
-    },
-    "custom": {
-      "type": "token",
-      "description": "Custom license. Define your own terms for how others can use, adapt, or share your content."
     }
   }
 }

--- a/lexicons/place/stream/default/metadata.json
+++ b/lexicons/place/stream/default/metadata.json
@@ -139,7 +139,7 @@
       "type": "token",
       "description": "Public domain dedication. You waive all copyright and related rights where possible. Others may copy, modify, distribute, or perform your work for any purpose without attribution."
     },
-    "cc-by_4_00": {
+    "cc-by_4__0": {
       "type": "token",
       "description": "Attribution required. Others may copy, distribute, remix, and build upon your work, even commercially, if they credit you."
     },


### PR DESCRIPTION
 - 4_00 -> 4__0
 -  removes place.stream.default.metadata#custom as custom values
