### PR TITLE
add metadata handling to websocket

### DIFF
--- a/js/app/components/content-metadata-form.tsx
+++ b/js/app/components/content-metadata-form.tsx
@@ -1,17 +1,12 @@
 import { ChevronDown, Info } from "@tamagui/lucide-icons";
 import { useToastController } from "@tamagui/toast";
 import {
-  createStreamKeyRecord,
-  selectStoredKey,
-} from "features/bluesky/blueskySlice";
-import {
-  createContentMetadata,
   getContentMetadata,
+  saveContentMetadata,
   selectError,
   selectIsCreating,
   selectIsUpdating,
-  selectLastCreatedRecord,
-  updateContentMetadata,
+  selectMetadata,
 } from "features/bluesky/contentMetadataSlice";
 import React, { useEffect, useState } from "react";
 import { useWindowDimensions } from "react-native";
@@ -180,13 +175,9 @@ export default function ContentMetadataForm({
   const isUpdating = useAppSelector(selectIsUpdating);
   const isCreating = useAppSelector(selectIsCreating);
   const error = useAppSelector(selectError);
-  const lastCreatedRecord = useAppSelector(selectLastCreatedRecord);
-  const storedKey = useAppSelector(selectStoredKey);
+  const metadata = useAppSelector(selectMetadata);
 
   const isLoading = isUpdating || isCreating;
-  // Check if we have metadata based on the fetched record
-  const hasMetadata = Boolean(lastCreatedRecord?.record);
-  const hasStreamKey = Boolean(storedKey);
 
   const [contentWarnings, setContentWarnings] = useState<string[]>(
     initialMetadata?.contentWarnings || [],
@@ -225,8 +216,8 @@ export default function ContentMetadataForm({
 
   // Pre-populate form fields when existing metadata is fetched
   useEffect(() => {
-    if (lastCreatedRecord?.record && !hasPopulated) {
-      const record = lastCreatedRecord.record;
+    if (metadata && !hasPopulated) {
+      const record = metadata;
 
       // Update content warnings
       if (record.contentWarnings && Array.isArray(record.contentWarnings)) {
@@ -276,7 +267,7 @@ export default function ContentMetadataForm({
       }
 
       // Update the parent component with the loaded metadata
-      const metadata: ContentMetadata = {
+      const updatedMetadata: ContentMetadata = {
         contentWarnings: record.contentWarnings || [],
         distributionPolicy: {
           allowArchive: record.distributionPolicy?.allowArchive ?? true,
@@ -284,12 +275,12 @@ export default function ContentMetadataForm({
         },
         contentRights: record.contentRights || {},
       };
-      onMetadataChange(metadata);
+      onMetadataChange(updatedMetadata);
 
       // Mark as populated to prevent future overwrites
       setHasPopulated(true);
     }
-  }, [lastCreatedRecord, onMetadataChange, months, hasPopulated]);
+  }, [metadata, onMetadataChange, months, hasPopulated]);
 
   const handleContentWarningChange = (warning: string, checked: boolean) => {
     const newWarnings = checked
@@ -363,11 +354,6 @@ export default function ContentMetadataForm({
 
   const handleSaveMetadata = async () => {
     try {
-      // First ensure we have a stream key
-      if (!hasStreamKey) {
-        await dispatch(createStreamKeyRecord({ store: true })).unwrap();
-      }
-
       const contentRightsData = {
         ...(contentRights.creator && { creator: contentRights.creator }),
         ...(contentRights.copyrightNotice && {
@@ -395,33 +381,14 @@ export default function ContentMetadataForm({
         }),
       };
 
-      if (hasMetadata) {
-        // Update existing metadata
-        await dispatch(
-          updateContentMetadata({
-            rkey: "self",
-            ...metadataPayload,
-          }),
-        ).unwrap();
-        toast.show("Success", {
-          message: "Content metadata updated successfully",
-        });
-      } else {
-        // Create new metadata
-        await dispatch(
-          (createContentMetadata as any)({
-            contentWarnings,
-            distributionPolicy,
-            contentRights,
-          }),
-        ).unwrap();
-        toast.show("Success", {
-          message: "Content metadata created successfully",
-        });
-      }
+      // Use saveContentMetadata (follows chat profile pattern with putRecord)
+      await dispatch(saveContentMetadata(metadataPayload)).unwrap();
+      toast.show("Success", {
+        message: "Content metadata saved successfully",
+      });
     } catch (error) {
       toast.show("Error", {
-        message: `Failed to ${hasMetadata ? "update" : "create"} metadata: ${error.message || error}`,
+        message: `Failed to save metadata: ${error.message || error}`,
       });
     }
   };
@@ -1072,13 +1039,7 @@ export default function ContentMetadataForm({
             maxWidth={400}
             onPress={handleSaveMetadata}
           >
-            {isLoading
-              ? isCreating
-                ? "Creating..."
-                : "Updating..."
-              : hasMetadata
-                ? "Update Content Metadata"
-                : "Create Content Metadata"}
+            {isLoading ? "Saving..." : "Save Content Metadata"}
           </Button>
           {error && (
             <Paragraph color="$red10" fontSize="$1" mt="$1">

--- a/js/app/components/content-rights.tsx
+++ b/js/app/components/content-rights.tsx
@@ -29,15 +29,7 @@ export default function ContentRights({
   contentRights,
   compact = false,
 }: ContentRightsProps) {
-  console.log(
-    `[ContentRights] Rendering with rights:`,
-    contentRights,
-    `compact:`,
-    compact,
-  );
-
   if (!contentRights || Object.keys(contentRights).length === 0) {
-    console.log(`[ContentRights] No content rights to display, returning null`);
     return null;
   }
 
@@ -74,9 +66,6 @@ export default function ContentRights({
   }
 
   if (rightsParts.length === 0) {
-    console.log(
-      `[ContentRights] No displayable rights information, returning null`,
-    );
     return null;
   }
 

--- a/js/app/components/content-warnings.tsx
+++ b/js/app/components/content-warnings.tsx
@@ -23,15 +23,7 @@ export default function ContentWarnings({
   warnings,
   compact = false,
 }: ContentWarningsProps) {
-  console.log(
-    `[ContentWarnings] Rendering with warnings:`,
-    warnings,
-    `compact:`,
-    compact,
-  );
-
   if (!warnings || warnings.length === 0) {
-    console.log(`[ContentWarnings] No warnings to display, returning null`);
     return null;
   }
 

--- a/js/app/components/metadata-sync.tsx
+++ b/js/app/components/metadata-sync.tsx
@@ -1,0 +1,65 @@
+import { useStreamplaceStore } from "@streamplace/components";
+import { updateMultipleMetadataFromPoller } from "features/bluesky/contentMetadataSlice";
+import { useEffect, useMemo, useRef } from "react";
+import { useAppDispatch } from "store/hooks";
+
+// This component bridges the gap between streamplace store and Redux metadata store
+// It listens to changes in liveUsersMetadata from the poller and updates the Redux cache
+export default function MetadataSync() {
+  const dispatch = useAppDispatch();
+  const liveUsers = useStreamplaceStore((state) => state.liveUsers);
+  const liveUsersMetadata = useStreamplaceStore(
+    (state) => state.liveUsersMetadata,
+  );
+  const lastUpdatesRef = useRef<{ [key: string]: any }>({});
+
+  // Memoize the metadata updates to prevent unnecessary dispatches
+  const metadataUpdates = useMemo(() => {
+    if (liveUsers === null) return null;
+
+    const updates: { [key: string]: any } = {};
+
+    // Only add metadata for users that are currently live
+    if (
+      liveUsers.length > 0 &&
+      liveUsersMetadata &&
+      liveUsers.length === liveUsersMetadata.length
+    ) {
+      for (let i = 0; i < liveUsers.length; i++) {
+        const user = liveUsers[i];
+        const metadata = liveUsersMetadata[i];
+
+        if (user && user.author && user.author.did) {
+          // Extract the metadata value from the LexiconTypeDecoder if it exists
+          const metadataValue = metadata?.val || metadata;
+          updates[user.author.did] = metadataValue;
+        }
+      }
+    }
+
+    return updates;
+  }, [liveUsers, liveUsersMetadata]);
+
+  useEffect(() => {
+    if (metadataUpdates === null) return;
+
+    // Only dispatch if the metadata has actually changed
+    const hasChanged =
+      JSON.stringify(metadataUpdates) !==
+      JSON.stringify(lastUpdatesRef.current);
+
+    if (hasChanged) {
+      console.log(
+        "MetadataSync: Syncing metadata cache for",
+        Object.keys(metadataUpdates).length,
+        "live users:",
+        metadataUpdates,
+      );
+      lastUpdatesRef.current = metadataUpdates;
+      dispatch(updateMultipleMetadataFromPoller(metadataUpdates));
+    }
+  }, [metadataUpdates, dispatch]);
+
+  // This component doesn't render anything, it just syncs data
+  return null;
+}

--- a/js/app/components/mobile/bottom-metadata.tsx
+++ b/js/app/components/mobile/bottom-metadata.tsx
@@ -30,8 +30,8 @@ export function BottomMetadata({
   const ls = useLivestreamStore((x) => x.livestream);
 
   // Get content warnings and rights for the streamer
-  const { warnings: contentWarnings } = useContentWarnings(profile?.did);
-  const { contentRights } = useContentRights(profile?.did);
+  const { warnings: contentWarnings } = useContentWarnings();
+  const { contentRights } = useContentRights();
 
   return (
     <View

--- a/js/app/components/mobile/ui.tsx
+++ b/js/app/components/mobile/ui.tsx
@@ -51,8 +51,8 @@ export function MobileUi() {
   const avatars = useAvatars(profile?.did ? [profile?.did] : []);
 
   // Get content warnings and rights for the streamer
-  const { warnings: contentWarnings } = useContentWarnings(profile?.did);
-  const { contentRights } = useContentRights(profile?.did);
+  const { warnings: contentWarnings } = useContentWarnings();
+  const { contentRights } = useContentRights();
 
   const muteWasForced = usePlayerStore((state) => state.muteWasForced);
   const setMuteWasForced = usePlayerStore((state) => state.setMuteWasForced);

--- a/js/app/components/provider/provider.shared.tsx
+++ b/js/app/components/provider/provider.shared.tsx
@@ -16,6 +16,7 @@ import { useAppSelector } from "store/hooks";
 import { store } from "store/store";
 import { PortalProvider, TamaguiProvider } from "tamagui";
 import config from "tamagui.config";
+import MetadataSync from "../metadata-sync";
 import { CurrentToast } from "./CurrentToast";
 export default function Provider({
   children,
@@ -31,6 +32,7 @@ export default function Provider({
           <StreamplaceProvider>
             <BlueskyProvider>
               <NewStreamplaceProvider>
+                <MetadataSync />
                 <PortalProvider>
                   <ToastProvider
                     swipeDirection="vertical"

--- a/js/app/features/bluesky/blueskySlice.tsx
+++ b/js/app/features/bluesky/blueskySlice.tsx
@@ -39,6 +39,7 @@ const initialState: BlueskyState = {
   anonPDSAgent: null,
   profiles: {},
   profileCache: {},
+  metadataCache: {},
   client: null,
   login: {
     loading: false,

--- a/js/app/features/bluesky/blueskyTypes.tsx
+++ b/js/app/features/bluesky/blueskyTypes.tsx
@@ -4,6 +4,7 @@ import { OAuthSession } from "@atproto/oauth-client";
 import { StreamKey } from "features/base/baseSlice";
 import {
   PlaceStreamChatProfile,
+  PlaceStreamDefaultMetadata,
   PlaceStreamLivestream,
   PlaceStreamServerSettings,
   StreamplaceAgent,
@@ -25,6 +26,8 @@ export interface BlueskyState {
   profiles: { [key: string]: ProfileViewDetailed };
   // for e.g. others' avatars
   profileCache: { [key: string]: ProfileViewDetailed };
+  // for e.g. others' metadata
+  metadataCache: { [key: string]: PlaceStreamDefaultMetadata.Record };
   client: null | StreamplaceOAuthClient;
   login: {
     loading: boolean;

--- a/js/app/features/bluesky/contentMetadataSlice.tsx
+++ b/js/app/features/bluesky/contentMetadataSlice.tsx
@@ -5,357 +5,194 @@ export interface ContentMetadataState {
   creating: boolean;
   updating: boolean;
   error: string | null;
-  lastCreatedRecord: any | null;
+  metadata: any | null;
+  metadataCache: { [key: string]: any };
 }
 
 const initialState: ContentMetadataState = {
   creating: false,
   updating: false,
   error: null,
-  lastCreatedRecord: null,
+  metadata: null,
+  metadataCache: {},
 };
 
 export const contentMetadataSlice = createAppSlice({
   name: "contentMetadata",
   initialState,
   reducers: (create) => ({
-    createContentMetadata: create.asyncThunk(
+    saveContentMetadata: create.asyncThunk(
       async (
-        {
-          contentWarnings = [],
-          distributionPolicy = {
-            allowArchive: true,
-          },
-          contentRights = {},
-        }: {
+        payload: {
           contentWarnings?: string[];
           distributionPolicy?: {
             allowArchive?: boolean;
             broadcastExpiry?: string;
           };
-          contentRights?: {
-            creator?: string;
-            copyrightNotice?: string;
-            copyrightYear?: number;
-            license?: string;
-            creditLine?: string;
-          };
+          contentRights?: Record<string, any>;
         },
         thunkAPI,
       ) => {
-        const { bluesky } = thunkAPI.getState() as {
-          bluesky: BlueskyState;
-        };
+        const { bluesky } = thunkAPI.getState() as { bluesky: BlueskyState };
 
-        if (!bluesky.pdsAgent) {
-          throw new Error("No agent");
-        }
-
-        const did = bluesky.oauthSession?.did;
-        if (!did) {
-          throw new Error("No DID");
+        if (!bluesky.pdsAgent || !bluesky.oauthSession?.did) {
+          throw new Error("Not authenticated");
         }
 
         const metadataRecord = {
           $type: "place.stream.default.metadata",
           createdAt: new Date().toISOString(),
-          ...(contentWarnings.length > 0 && { contentWarnings }),
-          distributionPolicy,
-          ...(contentRights &&
-            Object.keys(contentRights).length > 0 && {
-              contentRights,
+          ...(payload.contentWarnings &&
+            payload.contentWarnings.length > 0 && {
+              contentWarnings: payload.contentWarnings,
             }),
-        };
-
-        const result = await bluesky.pdsAgent.com.atproto.repo.createRecord({
-          repo: did,
-          collection: "place.stream.default.metadata",
-          rkey: "self",
-          record: metadataRecord,
-        });
-
-        // Extract rkey from the URI
-        const rkey = result.data.uri.split("/").pop();
-
-        return {
-          record: metadataRecord,
-          uri: result.data.uri,
-          cid: result.data.cid,
-          rkey,
-        };
-      },
-      {
-        pending: (state) => {
-          return {
-            ...state,
-            creating: true,
-            error: null,
-          };
-        },
-        fulfilled: (state, action) => {
-          return {
-            ...state,
-            creating: false,
-            error: null,
-            lastCreatedRecord: action.payload,
-          };
-        },
-        rejected: (state, action) => {
-          return {
-            ...state,
-            creating: false,
-            error: action.error?.message ?? "Failed to create content metadata",
-          };
-        },
-      },
-    ),
-
-    updateContentMetadata: create.asyncThunk(
-      async (
-        {
-          rkey,
-          livestreamRef,
-          contentWarnings = [],
-          distributionPolicy = {
+          distributionPolicy: payload.distributionPolicy || {
             allowArchive: true,
-            broadcastExpiry: undefined, // No expiration means forever
           },
-          contentRights = {},
-        }: {
-          rkey?: string;
-          livestreamRef?: {
-            uri: string;
-            cid: string;
-          };
-          contentWarnings?: string[];
-          distributionPolicy?: {
-            allowArchive?: boolean;
-            broadcastExpiry?: string;
-          };
-          contentRights?: {
-            year?: string;
-            attribution?: string;
-            license?: string;
-            usageTerms?: string;
-          };
-        },
-        thunkAPI,
-      ) => {
-        const { bluesky } = thunkAPI.getState() as {
-          bluesky: BlueskyState;
-        };
-
-        if (!bluesky.pdsAgent) {
-          throw new Error("No agent");
-        }
-
-        const did = bluesky.oauthSession?.did;
-        if (!did) {
-          throw new Error("No DID");
-        }
-
-        const metadataRecord = {
-          $type: "place.stream.default.metadata",
-          ...(livestreamRef && { livestreamRef }),
-          createdAt: new Date().toISOString(),
-          ...(contentWarnings.length > 0 && { contentWarnings }),
-          distributionPolicy,
-          ...(contentRights &&
-            Object.keys(contentRights).length > 0 && {
-              contentRights,
+          ...(payload.contentRights &&
+            Object.keys(payload.contentRights).length > 0 && {
+              contentRights: payload.contentRights,
             }),
         };
 
         const result = await bluesky.pdsAgent.com.atproto.repo.putRecord({
-          repo: did,
+          repo: bluesky.oauthSession.did,
           collection: "place.stream.default.metadata",
           rkey: "self",
           record: metadataRecord,
         });
 
-        return {
-          record: metadataRecord,
-          uri: `at://${did}/place.stream.default.metadata/self`,
-          cid: result.data.cid,
-        };
+        return metadataRecord;
       },
       {
-        pending: (state) => {
-          return {
-            ...state,
-            updating: true,
-            error: null,
-          };
-        },
-        fulfilled: (state, action) => {
-          return {
-            ...state,
-            updating: false,
-            error: null,
-            lastCreatedRecord: action.payload,
-          };
-        },
-        rejected: (state, action) => {
-          return {
-            ...state,
-            updating: false,
-            error: action.error?.message ?? "Failed to update content metadata",
-          };
-        },
+        pending: (state) => ({
+          ...state,
+          creating: true,
+          updating: true,
+          error: null,
+        }),
+        fulfilled: (state, action) => ({
+          ...state,
+          creating: false,
+          updating: false,
+          metadata: action.payload,
+        }),
+        rejected: (state, action) => ({
+          ...state,
+          creating: false,
+          updating: false,
+          error: action.error?.message || "Failed to save metadata",
+        }),
       },
     ),
 
     getContentMetadata: create.asyncThunk(
-      async (
-        { userDid, rkey = "self" }: { userDid?: string; rkey?: string } = {},
-        thunkAPI,
-      ) => {
-        const { bluesky } = thunkAPI.getState() as {
-          bluesky: BlueskyState;
-        };
+      async (payload: { userDid?: string; rkey?: string } = {}, thunkAPI) => {
+        const { bluesky } = thunkAPI.getState() as { bluesky: BlueskyState };
+        const { userDid, rkey = "self" } = payload;
 
-        if (!bluesky.pdsAgent) {
-          throw new Error("No agent");
+        if (!bluesky.pdsAgent || !bluesky.oauthSession?.did) {
+          throw new Error("Not authenticated");
         }
 
-        // Use provided userDid or fall back to current user's DID
         const targetDid = userDid || bluesky.oauthSession?.did;
         if (!targetDid) {
-          throw new Error("No DID provided or user not authenticated");
+          throw new Error("No DID provided");
         }
 
-        // Add debugging information
-        console.log(`[getContentMetadata] Debug info:`, {
-          targetDid,
-          rkey,
-          pdsAgentType: bluesky.pdsAgent.constructor.name,
-          hasOAuthSession: !!bluesky.oauthSession,
-          currentUserDid: bluesky.oauthSession?.did,
-          pdsAgentHost:
-            (bluesky.pdsAgent as any)?.host ||
-            (bluesky.pdsAgent as any)?.service?.host ||
-            "unknown",
-          pdsAgentUrl:
-            (bluesky.pdsAgent as any)?.url ||
-            (bluesky.pdsAgent as any)?.service?.url ||
-            "unknown",
-        });
-
         try {
-          // First, try to resolve the correct PDS for the target user
-          let targetPDS = null;
-          try {
-            const didResponse = await fetch(
-              `https://plc.directory/${targetDid}`,
-            );
-            if (didResponse.ok) {
-              const didDoc = await didResponse.json();
-              const pdsService = didDoc.service?.find(
-                (s: any) => s.id === "#atproto_pds",
-              );
-              if (pdsService) {
-                targetPDS = pdsService.serviceEndpoint;
-                console.log(
-                  `[getContentMetadata] Resolved PDS for ${targetDid}:`,
-                  targetPDS,
-                );
-              }
-            }
-          } catch (pdsResolveError) {
-            console.log(
-              `[getContentMetadata] Failed to resolve PDS for ${targetDid}:`,
-              pdsResolveError,
-            );
-          }
-
-          // Use the target PDS if available, otherwise fall back to the current agent
-          let agent = bluesky.pdsAgent;
-          if (targetPDS && targetPDS !== (bluesky.pdsAgent as any)?.host) {
-            // Create a new agent pointing to the target PDS
-            const { StreamplaceAgent } = await import("streamplace");
-            agent = new StreamplaceAgent(targetPDS) as any;
-            console.log(
-              `[getContentMetadata] Created new agent for PDS:`,
-              targetPDS,
-            );
-          }
-
-          console.log(`[getContentMetadata] Attempting to fetch record from:`, {
-            repo: targetDid,
-            collection: "place.stream.default.metadata",
-            rkey,
-            usingPDS: targetPDS || "default",
-          });
-
-          const result = await agent.com.atproto.repo.getRecord({
+          // Use the authenticated pdsAgent to ensure proper DPoP authentication
+          const result = await bluesky.pdsAgent.com.atproto.repo.getRecord({
             repo: targetDid,
             collection: "place.stream.default.metadata",
             rkey,
           });
-
-          console.log(`[getContentMetadata] API response:`, result);
-
-          if (!result.success) {
-            throw new Error("Failed to get content metadata record");
-          }
 
           return {
             userDid: targetDid,
-            record: result.data.value,
-            uri: result.data.uri,
-            cid: result.data.cid,
+            record: result.success ? result.data.value : null,
+            uri: result.success ? result.data.uri : null,
+            cid: result.success ? result.data.cid : null,
           };
         } catch (error) {
-          console.log(`[getContentMetadata] Error details:`, {
-            error: error.message,
-            errorType: error.constructor.name,
-            errorStack: error.stack,
-          });
-
-          // If user doesn't have metadata record, return null instead of throwing
+          // Return null for not found, rather than throwing
           if (
             error.message?.includes("not found") ||
             error.message?.includes("RecordNotFound")
           ) {
-            return {
-              userDid: targetDid,
-              record: null,
-              uri: null,
-              cid: null,
-            };
+            return { userDid: targetDid, record: null, uri: null, cid: null };
           }
           throw error;
         }
       },
       {
-        pending: (state) => {
-          return {
-            ...state,
-            error: null,
-          };
-        },
+        pending: (state) => ({ ...state, error: null }),
         fulfilled: (state, action) => {
+          const { userDid, record } = action.payload;
           return {
             ...state,
             error: null,
-            lastCreatedRecord: action.payload,
+            metadata: record,
+            metadataCache: { ...state.metadataCache, [userDid]: record },
           };
         },
-        rejected: (state, action) => {
-          return {
-            ...state,
-            error: action.error?.message ?? "Failed to get content metadata",
-          };
-        },
+        rejected: (state, action) => ({
+          ...state,
+          error: action.error?.message || "Failed to get metadata",
+        }),
       },
     ),
 
-    clearError: create.reducer((state) => {
-      return {
+    getMultipleMetadata: create.asyncThunk(
+      async (userDids: string[], thunkAPI) => {
+        const { bluesky } = thunkAPI.getState() as { bluesky: BlueskyState };
+
+        if (!bluesky.pdsAgent || !bluesky.oauthSession?.did) {
+          throw new Error("Not authenticated");
+        }
+
+        const results: { [key: string]: any } = {};
+
+        // Process each DID using the authenticated agent
+        for (const userDid of userDids) {
+          try {
+            const result = await bluesky.pdsAgent.com.atproto.repo.getRecord({
+              repo: userDid,
+              collection: "place.stream.default.metadata",
+              rkey: "self",
+            });
+
+            results[userDid] = result.success ? result.data.value : null;
+          } catch (error) {
+            // Set to null for not found or any other error
+            results[userDid] = null;
+          }
+        }
+
+        return results;
+      },
+      {
+        pending: (state) => ({ ...state, error: null }),
+        fulfilled: (state, action) => ({
+          ...state,
+          error: null,
+          metadataCache: { ...state.metadataCache, ...action.payload },
+        }),
+        rejected: (state, action) => ({
+          ...state,
+          error: action.error?.message || "Failed to get multiple metadata",
+        }),
+      },
+    ),
+
+    clearError: create.reducer((state) => ({ ...state, error: null })),
+
+    updateMultipleMetadataFromPoller: create.reducer(
+      (state, action: { payload: { [key: string]: any } }) => ({
         ...state,
-        error: null,
-      };
-    }),
+        metadataCache: action.payload, // Replace cache with live users only
+      }),
+    ),
   }),
 
   selectors: {
@@ -363,15 +200,17 @@ export const contentMetadataSlice = createAppSlice({
     selectIsCreating: (state) => state.creating,
     selectIsUpdating: (state) => state.updating,
     selectError: (state) => state.error,
-    selectLastCreatedRecord: (state) => state.lastCreatedRecord,
+    selectMetadata: (state) => state.metadata,
+    selectCachedMetadata: (state) => state.metadataCache,
   },
 });
 
 export const {
-  createContentMetadata,
-  updateContentMetadata,
+  saveContentMetadata,
   getContentMetadata,
+  getMultipleMetadata,
   clearError,
+  updateMultipleMetadataFromPoller,
 } = contentMetadataSlice.actions;
 
 export const {
@@ -379,5 +218,6 @@ export const {
   selectIsCreating,
   selectIsUpdating,
   selectError,
-  selectLastCreatedRecord,
+  selectMetadata,
+  selectCachedMetadata,
 } = contentMetadataSlice.selectors;

--- a/js/app/hooks/useContentRights.tsx
+++ b/js/app/hooks/useContentRights.tsx
@@ -1,6 +1,5 @@
-import { getContentMetadata } from "features/bluesky/contentMetadataSlice";
-import { useEffect, useRef, useState } from "react";
-import { useAppDispatch, useAppSelector } from "store/hooks";
+import { useLivestreamStore } from "@streamplace/components";
+import { useEffect, useState } from "react";
 
 interface ContentRightsHookResult {
   contentRights: {
@@ -14,175 +13,27 @@ interface ContentRightsHookResult {
   error: string | null;
 }
 
-// Reuse the same ContentWarningsManager class but adapt it for content rights
-class ContentRightsManager {
-  private static instance: ContentRightsManager;
-  private cache: Map<string, { contentRights: any; timestamp: number }> =
-    new Map();
-  private subscribers: Map<string, Set<(contentRights: any) => void>> =
-    new Map();
-  private pendingRequests: Map<string, Promise<void>> = new Map();
-  private readonly CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
-
-  static getInstance(): ContentRightsManager {
-    if (!ContentRightsManager.instance) {
-      ContentRightsManager.instance = new ContentRightsManager();
-    }
-    return ContentRightsManager.instance;
-  }
-
-  subscribe(
-    userDid: string,
-    callback: (contentRights: any) => void,
-  ): () => void {
-    if (!this.subscribers.has(userDid)) {
-      this.subscribers.set(userDid, new Set());
-    }
-
-    const userSubscribers = this.subscribers.get(userDid)!;
-    userSubscribers.add(callback);
-
-    // Return unsubscribe function
-    return () => {
-      userSubscribers.delete(callback);
-      if (userSubscribers.size === 0) {
-        this.subscribers.delete(userDid);
-      }
-    };
-  }
-
-  private notifySubscribers(userDid: string, contentRights: any): void {
-    const userSubscribers = this.subscribers.get(userDid);
-    if (userSubscribers) {
-      userSubscribers.forEach((callback) => callback(contentRights));
-    }
-  }
-
-  async fetchContentRights(userDid: string, dispatch: any): Promise<void> {
-    // Check cache first
-    const cached = this.cache.get(userDid);
-    if (cached && Date.now() - cached.timestamp < this.CACHE_DURATION) {
-      console.log(
-        `[ContentRightsManager] Using cached rights for ${userDid}:`,
-        cached.contentRights,
-      );
-      this.notifySubscribers(userDid, cached.contentRights);
-      return;
-    }
-
-    // Check if request is already pending
-    if (this.pendingRequests.has(userDid)) {
-      console.log(
-        `[ContentRightsManager] Request already pending for ${userDid}, waiting...`,
-      );
-      await this.pendingRequests.get(userDid);
-      return;
-    }
-
-    // Create new request
-    const requestPromise = this.performFetch(userDid, dispatch);
-    this.pendingRequests.set(userDid, requestPromise);
-
-    try {
-      await requestPromise;
-    } finally {
-      this.pendingRequests.delete(userDid);
-    }
-  }
-
-  private async performFetch(userDid: string, dispatch: any): Promise<void> {
-    try {
-      const result = await dispatch(getContentMetadata({ userDid })).unwrap();
-
-      const contentRights = result.record?.contentRights || {};
-
-      // Cache the result
-      this.cache.set(userDid, {
-        contentRights,
-        timestamp: Date.now(),
-      });
-
-      // Notify all subscribers
-      this.notifySubscribers(userDid, contentRights);
-    } catch (err: any) {
-      console.log(
-        `[ContentRightsManager] Error fetching metadata for ${userDid}:`,
-        err,
-      );
-      // Don't cache errors, but notify subscribers with empty object
-      this.notifySubscribers(userDid, {});
-    }
-  }
-
-  getCachedContentRights(userDid: string): any {
-    const cached = this.cache.get(userDid);
-    return cached ? cached.contentRights : {};
-  }
-}
-
-export function useContentRights(
-  userDid: string | undefined,
-): ContentRightsHookResult {
-  const dispatch = useAppDispatch();
-  const pdsAgent = useAppSelector((state) => state.bluesky.pdsAgent);
+export function useContentRights(): ContentRightsHookResult {
+  const defaultMetadata = useLivestreamStore((x) => x.defaultMetadata);
   const [contentRights, setContentRights] = useState<any>({});
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const unsubscribeRef = useRef<(() => void) | null>(null);
-  const manager = ContentRightsManager.getInstance();
 
   useEffect(() => {
-    if (!userDid) {
-      setContentRights({});
-      setLoading(false);
-      setError(null);
-      return;
-    }
+    // Extract content rights from metadata
+    if (defaultMetadata) {
+      const rights = defaultMetadata.contentRights || {};
 
-    // Wait for PDS agent to be available
-    if (!pdsAgent) {
-      console.log(`[useContentRights] PDS agent not ready yet, waiting...`);
-      return;
-    }
-
-    // Set initial state from cache
-    const cachedRights = manager.getCachedContentRights(userDid);
-    if (cachedRights && Object.keys(cachedRights).length > 0) {
-      console.log(
-        `[useContentRights] Setting initial state from cache for ${userDid}:`,
-        cachedRights,
-      );
-      setContentRights(cachedRights);
+      setContentRights(rights);
       setLoading(false);
       setError(null);
     } else {
-      setLoading(true);
-    }
-
-    // Subscribe to updates
-    const unsubscribe = manager.subscribe(userDid, (newRights) => {
-      console.log(
-        `[useContentRights] Received update for ${userDid}:`,
-        newRights,
-      );
-      setContentRights(newRights);
+      // No metadata available - not loading, just empty
+      setContentRights({});
       setLoading(false);
       setError(null);
-    });
-
-    unsubscribeRef.current = unsubscribe;
-
-    // Fetch content rights
-    manager.fetchContentRights(userDid, dispatch);
-
-    // Cleanup subscription on unmount
-    return () => {
-      if (unsubscribeRef.current) {
-        unsubscribeRef.current();
-        unsubscribeRef.current = null;
-      }
-    };
-  }, [userDid, pdsAgent, dispatch]);
+    }
+  }, [defaultMetadata]);
 
   return { contentRights, loading, error };
 }

--- a/js/app/hooks/useContentWarnings.tsx
+++ b/js/app/hooks/useContentWarnings.tsx
@@ -1,6 +1,5 @@
-import { getContentMetadata } from "features/bluesky/contentMetadataSlice";
-import { useEffect, useRef, useState } from "react";
-import { useAppDispatch, useAppSelector } from "store/hooks";
+import { useLivestreamStore } from "@streamplace/components";
+import { useEffect, useState } from "react";
 
 interface ContentWarningsHookResult {
   warnings: string[];
@@ -8,193 +7,29 @@ interface ContentWarningsHookResult {
   error: string | null;
 }
 
-// Global state manager to prevent conflicts between multiple hook instances
-class ContentWarningsManager {
-  private static instance: ContentWarningsManager;
-  private cache: Map<string, { warnings: string[]; timestamp: number }> =
-    new Map();
-  private subscribers: Map<string, Set<(warnings: string[]) => void>> =
-    new Map();
-  private pendingRequests: Map<string, Promise<void>> = new Map();
-  private readonly CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
-
-  static getInstance(): ContentWarningsManager {
-    if (!ContentWarningsManager.instance) {
-      ContentWarningsManager.instance = new ContentWarningsManager();
-    }
-    return ContentWarningsManager.instance;
-  }
-
-  subscribe(
-    userDid: string,
-    callback: (warnings: string[]) => void,
-  ): () => void {
-    if (!this.subscribers.has(userDid)) {
-      this.subscribers.set(userDid, new Set());
-    }
-
-    const userSubscribers = this.subscribers.get(userDid)!;
-    userSubscribers.add(callback);
-
-    // Return unsubscribe function
-    return () => {
-      userSubscribers.delete(callback);
-      if (userSubscribers.size === 0) {
-        this.subscribers.delete(userDid);
-      }
-    };
-  }
-
-  private notifySubscribers(userDid: string, warnings: string[]): void {
-    const userSubscribers = this.subscribers.get(userDid);
-    if (userSubscribers) {
-      userSubscribers.forEach((callback) => callback(warnings));
-    }
-  }
-
-  async fetchWarnings(userDid: string, dispatch: any): Promise<void> {
-    // Check cache first
-    const cached = this.cache.get(userDid);
-    if (cached && Date.now() - cached.timestamp < this.CACHE_DURATION) {
-      console.log(
-        `[ContentWarningsManager] Using cached warnings for ${userDid}:`,
-        cached.warnings,
-      );
-      this.notifySubscribers(userDid, cached.warnings);
-      return;
-    }
-
-    // Check if request is already pending
-    if (this.pendingRequests.has(userDid)) {
-      console.log(
-        `[ContentWarningsManager] Request already pending for ${userDid}, waiting...`,
-      );
-      await this.pendingRequests.get(userDid);
-      return;
-    }
-
-    // Create new request
-    const requestPromise = this.performFetch(userDid, dispatch);
-    this.pendingRequests.set(userDid, requestPromise);
-
-    try {
-      await requestPromise;
-    } finally {
-      this.pendingRequests.delete(userDid);
-    }
-  }
-
-  private async performFetch(userDid: string, dispatch: any): Promise<void> {
-    try {
-      console.log(`[ContentWarningsManager] Fetching metadata for ${userDid}`);
-
-      const result = await dispatch(getContentMetadata({ userDid })).unwrap();
-      console.log(
-        `[ContentWarningsManager] Metadata result for ${userDid}:`,
-        result,
-      );
-
-      const contentWarnings = Array.isArray(result.record?.contentWarnings)
-        ? result.record.contentWarnings
-        : [];
-
-      console.log(
-        `[ContentWarningsManager] Content warnings for ${userDid}:`,
-        contentWarnings,
-      );
-
-      // Cache the result
-      this.cache.set(userDid, {
-        warnings: contentWarnings,
-        timestamp: Date.now(),
-      });
-
-      // Notify all subscribers
-      this.notifySubscribers(userDid, contentWarnings);
-    } catch (err: any) {
-      console.log(
-        `[ContentWarningsManager] Error fetching metadata for ${userDid}:`,
-        err,
-      );
-      // Don't cache errors, but notify subscribers with empty array
-      this.notifySubscribers(userDid, []);
-    }
-  }
-
-  getCachedWarnings(userDid: string): string[] {
-    const cached = this.cache.get(userDid);
-    return cached ? cached.warnings : [];
-  }
-}
-
-export function useContentWarnings(
-  userDid: string | undefined,
-): ContentWarningsHookResult {
-  const dispatch = useAppDispatch();
-  const pdsAgent = useAppSelector((state) => state.bluesky.pdsAgent);
+export function useContentWarnings(): ContentWarningsHookResult {
+  const defaultMetadata = useLivestreamStore((x) => x.defaultMetadata);
   const [warnings, setWarnings] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const unsubscribeRef = useRef<(() => void) | null>(null);
-  const manager = ContentWarningsManager.getInstance();
 
   useEffect(() => {
-    console.log(
-      `[useContentWarnings] Effect running with userDid: ${userDid}, pdsAgent: ${!!pdsAgent}`,
-    );
+    // Extract content warnings from metadata
+    if (defaultMetadata) {
+      const contentWarnings = Array.isArray(defaultMetadata.contentWarnings)
+        ? defaultMetadata.contentWarnings
+        : [];
 
-    if (!userDid) {
-      console.log(`[useContentWarnings] No userDid provided, clearing state`);
-      setWarnings([]);
-      setLoading(false);
-      setError(null);
-      return;
-    }
-
-    // Wait for PDS agent to be available
-    if (!pdsAgent) {
-      console.log(`[useContentWarnings] PDS agent not ready yet, waiting...`);
-      return;
-    }
-
-    // Set initial state from cache
-    const cachedWarnings = manager.getCachedWarnings(userDid);
-    if (cachedWarnings.length > 0) {
-      console.log(
-        `[useContentWarnings] Setting initial state from cache for ${userDid}:`,
-        cachedWarnings,
-      );
-      setWarnings(cachedWarnings);
+      setWarnings(contentWarnings);
       setLoading(false);
       setError(null);
     } else {
-      setLoading(true);
-    }
-
-    // Subscribe to updates
-    const unsubscribe = manager.subscribe(userDid, (newWarnings) => {
-      console.log(
-        `[useContentWarnings] Received update for ${userDid}:`,
-        newWarnings,
-      );
-      setWarnings(newWarnings);
+      // No metadata available - not loading, just empty
+      setWarnings([]);
       setLoading(false);
       setError(null);
-    });
-
-    unsubscribeRef.current = unsubscribe;
-
-    // Fetch warnings
-    manager.fetchWarnings(userDid, dispatch);
-
-    // Cleanup subscription on unmount
-    return () => {
-      if (unsubscribeRef.current) {
-        unsubscribeRef.current();
-        unsubscribeRef.current = null;
-      }
-    };
-  }, [userDid, pdsAgent, dispatch]);
+    }
+  }, [defaultMetadata]);
 
   return { warnings, loading, error };
 }

--- a/js/app/hooks/useMetadata.tsx
+++ b/js/app/hooks/useMetadata.tsx
@@ -1,0 +1,30 @@
+import {
+  getMultipleMetadata,
+  selectCachedMetadata,
+} from "features/bluesky/contentMetadataSlice";
+import { useEffect, useMemo } from "react";
+import { useAppDispatch, useAppSelector } from "store/hooks";
+
+// Following the exact same pattern as useAvatars - just initial fetch, no polling
+// Live updates will come from getLiveUsers API just like titles and viewer counts
+export default function useMetadata(dids: string[]) {
+  const dispatch = useAppDispatch();
+  const metadata: Record<string, any> = useAppSelector(selectCachedMetadata);
+
+  const missingDids = useMemo(
+    () => dids.filter((did) => !(did in metadata)),
+    [dids, metadata],
+  );
+
+  // Initial fetch for missing DIDs only
+  useEffect(() => {
+    if (missingDids.length > 0) {
+      console.log("Fetching metadata for DIDs:", missingDids);
+      dispatch(getMultipleMetadata(missingDids)).then((e) =>
+        console.log("metadata ok", e),
+      );
+    }
+  }, [missingDids, dispatch]);
+
+  return metadata;
+}

--- a/js/app/src/screens/home.tsx
+++ b/js/app/src/screens/home.tsx
@@ -9,7 +9,7 @@ import LiveDot from "components/home/live-dot";
 import Loading from "components/loading/loading";
 import Title from "components/title";
 import useAvatars from "hooks/useAvatars";
-import { useContentWarnings } from "hooks/useContentWarnings";
+import useMetadata from "hooks/useMetadata";
 import { useEffect, useState } from "react";
 import { RefreshControl } from "react-native";
 import { PlaceStreamLivestream } from "streamplace";
@@ -111,16 +111,20 @@ function HomeScreenItem({
   media,
   size,
   avatarUrl,
+  metadata,
   horizontal = false,
 }: {
   item: PlaceStreamLivestream.LivestreamView;
   media: UseMediaState;
   size: StreamCardSize;
   avatarUrl?: string;
+  metadata?: any;
   horizontal?: boolean;
 }) {
   const user = item.author.handle || item.author.did;
-  const { warnings } = useContentWarnings(item.author.did);
+
+  // Get content warnings from the passed metadata
+  const contentWarnings = metadata?.contentWarnings || [];
 
   return (
     <AQLink
@@ -146,7 +150,7 @@ function HomeScreenItem({
         category={[]}
         viewers={item.viewerCount?.count}
         isLive={true}
-        contentWarnings={warnings}
+        contentWarnings={contentWarnings}
       />
     </AQLink>
   );
@@ -198,6 +202,7 @@ export default function HomeScreen({
   const media = useMedia();
 
   const avis = useAvatars((segments || []).map((s) => s.author.did));
+  const metadata = useMetadata((segments || []).map((s) => s.author.did));
 
   useEffect(() => {
     if (!liveUsersLoading) {
@@ -338,6 +343,7 @@ export default function HomeScreen({
                     media={media}
                     size={size}
                     avatarUrl={avis[item.author.did]?.avatar}
+                    metadata={metadata[item.author.did]}
                     horizontal={itemIndex == 0 && cols > 2}
                   />
                 </View>
@@ -377,6 +383,7 @@ export default function HomeScreen({
                           media={media}
                           size={size}
                           avatarUrl={avis[item.author.did]?.avatar}
+                          metadata={metadata[item.author.did]}
                         />
                       </View>
                     ) : (

--- a/js/components/src/livestream-store/livestream-state.tsx
+++ b/js/components/src/livestream-store/livestream-state.tsx
@@ -2,6 +2,7 @@ import { AppBskyActorDefs } from "@atproto/api";
 import {
   ChatMessageViewHydrated,
   LivestreamViewHydrated,
+  PlaceStreamDefaultMetadata,
   PlaceStreamDefs,
   PlaceStreamSegment,
 } from "streamplace";
@@ -21,6 +22,7 @@ export interface LivestreamState {
   replyToMessage: ChatMessageViewHydrated | null;
   streamKey: string | null;
   setStreamKey: (key: string | null) => void;
+  defaultMetadata: PlaceStreamDefaultMetadata.Record | null;
 }
 
 export interface LivestreamProblem {

--- a/js/components/src/livestream-store/livestream-store.tsx
+++ b/js/components/src/livestream-store/livestream-store.tsx
@@ -22,6 +22,7 @@ export const makeLivestreamStore = (): StoreApi<LivestreamState> => {
     authors: {},
     recentSegments: [],
     problems: [],
+    defaultMetadata: null,
   }));
 };
 
@@ -60,3 +61,6 @@ export const useLivestream = () => useLivestreamStore((x) => x.livestream);
 export const useSegment = () => useLivestreamStore((x) => x.segment);
 
 export const useRenditions = () => useLivestreamStore((x) => x.renditions);
+
+export const useDefaultMetadata = () =>
+  useLivestreamStore((x) => x.defaultMetadata);

--- a/js/components/src/livestream-store/websocket-consumer.tsx
+++ b/js/components/src/livestream-store/websocket-consumer.tsx
@@ -5,6 +5,7 @@ import {
   PlaceStreamChatDefs,
   PlaceStreamChatGate,
   PlaceStreamChatMessage,
+  PlaceStreamDefaultMetadata,
   PlaceStreamDefs,
   PlaceStreamLivestream,
   PlaceStreamSegment,
@@ -96,6 +97,12 @@ export const handleWebSocketMessages = (
         pendingHides: newPendingHides,
       };
       state = reduceChat(state, [], [], [hiddenMessageUri]);
+    } else if (PlaceStreamDefaultMetadata.isRecord(message)) {
+      const metadata = message as PlaceStreamDefaultMetadata.Record;
+      state = {
+        ...state,
+        defaultMetadata: metadata,
+      };
     }
   }
   return reduceChat(state, [], [], []);

--- a/js/components/src/streamplace-provider/poller.tsx
+++ b/js/components/src/streamplace-provider/poller.tsx
@@ -36,6 +36,7 @@ export default function Poller({ children }: { children: React.ReactNode }) {
         const res = await agent.place.stream.live.getLiveUsers();
         setLiveUsers({
           liveUsers: res.data.streams || [],
+          liveUsersMetadata: res.data.metadata || [],
           liveUsersLoading: false,
           liveUsersError: null,
         });

--- a/js/components/src/streamplace-store/streamplace-store.tsx
+++ b/js/components/src/streamplace-store/streamplace-store.tsx
@@ -19,8 +19,10 @@ import { StreamplaceContext } from "../streamplace-provider/context";
 export interface StreamplaceState {
   url: string;
   liveUsers: PlaceStreamLivestream.LivestreamView[] | null;
+  liveUsersMetadata: any[] | null; // Metadata corresponding to liveUsers
   setLiveUsers: (opts: {
     liveUsers?: PlaceStreamLivestream.LivestreamView[];
+    liveUsersMetadata?: any[];
     liveUsersLoading?: boolean;
     liveUsersError?: string | null;
     liveUsersRefresh?: number;
@@ -43,8 +45,10 @@ export const makeStreamplaceStore = ({
   return createStore<StreamplaceState>()((set) => ({
     url,
     liveUsers: null,
+    liveUsersMetadata: null,
     setLiveUsers: (opts: {
       liveUsers?: PlaceStreamLivestream.LivestreamView[];
+      liveUsersMetadata?: any[];
       liveUsersLoading?: boolean;
       liveUsersError?: string | null;
       liveUsersRefresh?: number;

--- a/lexicons/place/stream/live/getLiveUsers.json
+++ b/lexicons/place/stream/live/getLiveUsers.json
@@ -28,6 +28,13 @@
                 "type": "ref",
                 "ref": "place.stream.livestream#livestreamView"
               }
+            },
+            "metadata": {
+              "type": "array",
+              "items": {
+                "type": "unknown"
+              },
+              "description": "Content metadata records for the livestream users"
             }
           }
         }

--- a/pkg/api/websocket.go
+++ b/pkg/api/websocket.go
@@ -241,6 +241,22 @@ func (a *StreamplaceAPI) HandleWebsocket(ctx context.Context) httprouter.Handle 
 			}
 		}()
 
+		go func() {
+			metadata, err := a.Model.GetDefaultMetadata(ctx, repoDID)
+			if err != nil {
+				log.Error(ctx, "could not get default metadata", "error", err)
+				return
+			}
+			if metadata != nil {
+				streamplaceMetadata, err := metadata.ToStreamplaceDefaultMetadata()
+				if err != nil {
+					log.Error(ctx, "could not convert metadata to streamplace format", "error", err)
+					return
+				}
+				initialBurst <- streamplaceMetadata
+			}
+		}()
+
 		for {
 			messageType, message, err := conn.ReadMessage()
 			if err != nil {

--- a/pkg/atproto/sync.go
+++ b/pkg/atproto/sync.go
@@ -434,6 +434,14 @@ func (atsync *ATProtoSynchronizer) handleCreateUpdate(ctx context.Context, userD
 		err = atsync.Model.CreateDefaultMetadata(ctx, metadata)
 		if err != nil {
 			log.Error(ctx, "failed to create default metadata", "err", err)
+		} else {
+			// Publish metadata update to websocket subscribers
+			streamplaceMetadata, err := metadata.ToStreamplaceDefaultMetadata()
+			if err != nil {
+				log.Error(ctx, "failed to convert metadata to streamplace format", "err", err)
+			} else {
+				go atsync.Bus.Publish(userDID, streamplaceMetadata)
+			}
 		}
 	default:
 		log.Debug(ctx, "unhandled record type", "type", reflect.TypeOf(rec))

--- a/pkg/spxrpc/place_stream_live.go
+++ b/pkg/spxrpc/place_stream_live.go
@@ -86,8 +86,31 @@ func (s *Server) handlePlaceStreamLiveGetLiveUsers(ctx context.Context, before s
 		streams[i] = stream
 	}
 
+	// Fetch metadata for all users in parallel
+	var metadata []*util.LexiconTypeDecoder
+	for _, l := range ls {
+		userMetadata, err := s.model.GetDefaultMetadata(ctx, l.RepoDID)
+		if err != nil {
+			// If metadata fetch fails, just add nil and continue
+			metadata = append(metadata, nil)
+			continue
+		}
+		
+		if userMetadata != nil {
+			metadataRecord, err := userMetadata.ToStreamplaceDefaultMetadata()
+			if err == nil {
+				metadata = append(metadata, &util.LexiconTypeDecoder{Val: metadataRecord})
+			} else {
+				metadata = append(metadata, nil)
+			}
+		} else {
+			metadata = append(metadata, nil)
+		}
+	}
+
 	liveUsers := &placestreamtypes.LiveGetLiveUsers_Output{
-		Streams: streams,
+		Streams:  streams,
+		Metadata: metadata,
 	}
 
 	return liveUsers, nil

--- a/pkg/streamplace/livegetLiveUsers.go
+++ b/pkg/streamplace/livegetLiveUsers.go
@@ -12,7 +12,9 @@ import (
 
 // LiveGetLiveUsers_Output is the output of a place.stream.live.getLiveUsers call.
 type LiveGetLiveUsers_Output struct {
-	Streams []*Livestream_LivestreamView `json:"streams,omitempty" cborgen:"streams,omitempty"`
+	// metadata: Content metadata records for the livestream users
+	Metadata []*util.LexiconTypeDecoder   `json:"metadata,omitempty" cborgen:"metadata,omitempty"`
+	Streams  []*Livestream_LivestreamView `json:"streams,omitempty" cborgen:"streams,omitempty"`
 }
 
 // LiveGetLiveUsers calls the XRPC method "place.stream.live.getLiveUsers".


### PR DESCRIPTION
- implements real-time metadata synchronization for live streams and refactors content warnings/rights management for better maintainability.

### websocket metadata integration

  - added metadata support to websocket connections for real-time updates
  - enhanced websocket consumer to handle metadata push events
  - extended at protocol sync to include metadata change detection

### content metadata management refactor

  - new MetadataSync component bridges streamplace store and redux metadata store
  - streamlined useContentWarnings and useContentRights hooks to use shared patterns

 ### api improvements

  - server now includes user metadata alongside live stream data
  - to do: confirm this is the ideal location
  - this is used to get content warnings on the stream prewiew card on the homepage

  ### impact

  - real-time metadata updates propagate instantly via websocket
  - single source of truth for metadata state management

  ### lexicon changes
  
  - getLiveUsers api now includes metadata field
  
  ### known issues

  - ui metadata form don't populate with adequate state that matches the existing record data on component mount/ initial load
    - this appears to be the same error as the  chat.profile color
  - content filtering shows asymmetric behavior: removing warnings from filtered streams shows the stream being included near-instantly, but, on the other hand,
  adding warnings that should trigger filtering takes ~10 seconds before the stream disappears 
  