### PR TITLE
rename metadata record schema and edit distribution policies

### DIFF
--- a/lexicons/place/stream/default/metadata.json
+++ b/lexicons/place/stream/default/metadata.json
@@ -1,6 +1,6 @@
 {
   "lexicon": 1,
-  "id": "place.stream.default.metadata",
+  "id": "place.stream.metadata.configuration",
   "defs": {
     "main": {
       "type": "record",
@@ -14,16 +14,16 @@
             "items": {
               "type": "string",
               "knownValues": [
-                "place.stream.default.metadata#death",
-                "place.stream.default.metadata#drugUse",
-                "place.stream.default.metadata#fantasyViolence",
-                "place.stream.default.metadata#flashingLights",
-                "place.stream.default.metadata#language",
-                "place.stream.default.metadata#nudity",
-                "place.stream.default.metadata#PII",
-                "place.stream.default.metadata#sexuality",
-                "place.stream.default.metadata#suffering",
-                "place.stream.default.metadata#violence"
+                "place.stream.metadata.configuration#death",
+                "place.stream.metadata.configuration#drugUse",
+                "place.stream.metadata.configuration#fantasyViolence",
+                "place.stream.metadata.configuration#flashingLights",
+                "place.stream.metadata.configuration#language",
+                "place.stream.metadata.configuration#nudity",
+                "place.stream.metadata.configuration#PII",
+                "place.stream.metadata.configuration#sexuality",
+                "place.stream.metadata.configuration#suffering",
+                "place.stream.metadata.configuration#violence"
               ]
             },
             "description": "Content warnings for this stream."
@@ -59,14 +59,14 @@
           "type": "string",
           "description": "License URL or identifier.",
           "knownValues": [
-            "place.stream.default.metadata#all-rights-reserved",
-            "place.stream.default.metadata#cc0_1__0",
-            "place.stream.default.metadata#cc-by_4_00",
-            "place.stream.default.metadata#cc-by-sa_4__0",
-            "place.stream.default.metadata#cc-by-nc_4__0",
-            "place.stream.default.metadata#cc-by-nc-sa_4__0",
-            "place.stream.default.metadata#cc-by-nd_4__0",
-            "place.stream.default.metadata#cc-by-nc-nd_4__0"
+            "place.stream.metadata.configuration#all-rights-reserved",
+            "place.stream.metadata.configuration#cc0_1__0",
+            "place.stream.metadata.configuration#cc-by_4_00",
+            "place.stream.metadata.configuration#cc-by-sa_4__0",
+            "place.stream.metadata.configuration#cc-by-nc_4__0",
+            "place.stream.metadata.configuration#cc-by-nc-sa_4__0",
+            "place.stream.metadata.configuration#cc-by-nd_4__0",
+            "place.stream.metadata.configuration#cc-by-nc-nd_4__0"
           ]
         },
         "creditLine": {
@@ -79,14 +79,10 @@
       "type": "object",
       "description": "Distribution and rebroadcast policy.",
       "properties": {
-        "allowArchive": {
-          "type": "boolean",
-          "description": "Whether nodes can archive this stream."
-        },
-        "broadcastExpiry": {
+        "deleteAfter": {
           "type": "string",
           "format": "datetime",
-          "description": "When rebroadcast permissions expire. If not specified, there is no expiration on rebroadcast permission."
+          "description": "When this stream should be deleted. If not specified, the stream will be kept indefinitely."
         }
       }
     },


### PR DESCRIPTION
- renames `place.stream.default.metadata` to `place.stream.metadata.configuration`
- updates distribution policies:
  1. removes `allowArchive`
  2. renames `broadcastExpiry` to `deleteAfter`
